### PR TITLE
Fix/prevent duplicate button

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -60,9 +60,11 @@ class SocialShareButton {
         ? document.querySelector(this.options.container)
         : this.options.container;
       
-      if (container) {
-        container.appendChild(button);
+    if (container) {
+      if (!container.querySelector('.social-share-btn')) {
+      container.appendChild(button);
       }
+    }
     }
   }
 


### PR DESCRIPTION
Prevents multiple social share buttons from being appended to the same
container when SocialShareButton is initialized more than once.

This can occur in SPAs or during re-initialization. The fix ensures only
one button exists per container without changing existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate social share buttons could appear in the same container. The button now only inserts if one doesn't already exist in that location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->