### PR TITLE
fix: prevent HTML injection in modal URL input

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -82,12 +82,19 @@ class SocialShareButton {
         </div>
         <div class="social-share-link-container">
           <div class="social-share-link-input">
-            <input type="text" value="${this.options.url}" readonly aria-label="URL to share">
           </div>
           <button class="social-share-copy-btn">Copy</button>
         </div>
       </div>
     `;
+
+    const urlInputContainer = modal.querySelector('.social-share-link-input');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.value = this.options.url;
+    urlInput.readOnly = true;
+    urlInput.setAttribute('aria-label', 'URL to share');
+    urlInputContainer.appendChild(urlInput);
 
     this.modal = modal;
     document.body.appendChild(modal);


### PR DESCRIPTION
## Problem

The URL input uses string interpolation which allows HTML injection:
```javascript
<input type="text" value="${this.options.url}" readonly>
```

**Exploit:**
```javascript
new SocialShareButton({
  url: '"><img src=x onerror=alert(1)>'
});
```

---

## Solution

Use safe DOM methods instead of template strings:
```javascript
const urlInput = document.createElement('input');
urlInput.type = 'text';
urlInput.value = this.options.url;  
urlInput.readOnly = true;
urlInputContainer.appendChild(urlInput);
```

---

## Testing

<img width="1902" height="1024" alt="Screenshot_20260125_004029" src="https://github.com/user-attachments/assets/5a436434-8786-42c3-81ac-b0e036ad5042" />


**Results:**
- ✅ No XSS execution
- ✅ Malicious code displayed as text
- ✅ All functionality works
- ✅ Zero breaking changes

---

## Checklist

- [x] Security fix (XSS prevention)
- [x] Tested with malicious payload
- [x] No breaking changes
- [x] All demos work

Fixes #11



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced accessibility for the social share button with improved aria-label configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->