### PR TITLE
docs: add SECURITY.md to define vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,8 +21,6 @@ https://github.com/AOSSIE-Org/SocialShareButton/security/advisories/new
 
 Private reporting ensures the issue can be addressed responsibly without exposing users to unnecessary risk.
 
-+**Note:** If the link above does not work, private vulnerability reporting may not yet be enabled for this repository. A repository administrator can enable it by following the [GitHub Docs guide for configuring private vulnerability reporting for a repository](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository).
-
 ## What to Include in Your Report
 
 To help us investigate efficiently, please include:
@@ -39,7 +37,11 @@ Providing detailed information helps us respond more quickly and effectively.
 
 Once a vulnerability report is received:
 
-We will acknowledge receipt of the report, investigate and validate the issue, and work on a fix if the vulnerability is confirmed. We will coordinate responsible disclosure with the reporter before any public announcement.
+1. **Acknowledge** receipt of the report within **48 hours**.
+2. **Investigate and validate** the reported issue.
+3. **Develop and test** a fix if the vulnerability is confirmed.
+4. **Coordinate** responsible disclosure with the reporter before any public announcement.
+5. **Release** a prompt patch and notify the reporter.
 
 We kindly ask reporters to avoid public disclosure until a fix has been released, allowing us to protect users effectively.
 


### PR DESCRIPTION
Fixes: #18

Summary

This PR adds a SECURITY.md file to establish a responsible vulnerability disclosure process for the repository.

Previously, the repository did not provide formal guidance on reporting security vulnerabilities. Adding this file improves transparency, encourages responsible disclosure, and aligns the project with open-source security best practices.

This PR implements one best practice as specified in the issue instructions.

Changes Introduced

Added a structured Security Policy

Defined supported versions

Documented a private vulnerability reporting workflow via GitHub Security Advisories

Specified required details for vulnerability reports

Defined a 48-hour acknowledgment timeline

Established a responsible disclosure and coordinated release process

Impact

Improves project security governance

Provides clear guidance for security researchers

Aligns the repository with standard open-source security practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy describing supported branches, private vulnerability reporting via advisories, what to include in a report (description, reproduction steps, impact, proof-of-concept/logs/screenshots, mitigation), and the response & coordinated disclosure process (acknowledgement, investigation, fix development/testing, and guidance to avoid public disclosure until a fix is released).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->