### PR TITLE
feat: Host index.html Demo on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,38 @@
+# Deploy index.html demo to GitHub Pages
+name: Deploy Demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 <!-- Organization Name -->
 <div align="center">
 
-[![Static Badge](https://img.shields.io/badge/AOSSIE-Social_Share_Button-228B22?style=for-the-badge&labelColor=FFC517)](https://TODO.aossie/)
+[![Static Badge](https://img.shields.io/badge/AOSSIE-Social_Share_Button-228B22?style=for-the-badge&labelColor=FFC517)](https://aossie-org.github.io/SocialShareButton/)
 
-<!-- Correct deployed url to be added -->
+[![Live Demo](https://img.shields.io/badge/🚀_Live_Demo-Click_Here-blue?style=for-the-badge)](https://aossie-org.github.io/SocialShareButton/)
 
 </div>
 
@@ -655,8 +655,11 @@ new SocialShareButton({
 
 ## Demo
 
-Open `index.html` in your browser to see all features.
-Tutorial: https://youtu.be/cLJaT-8rEvQ?si=CLipA0Db4WL0EqKM
+🚀 **[Live Demo](https://aossie-org.github.io/SocialShareButton/)** - Try it now without cloning!
+
+Or open `index.html` locally in your browser to see all features.
+
+📺 Tutorial: https://youtu.be/cLJaT-8rEvQ?si=CLipA0Db4WL0EqKM
 
 ---
 


### PR DESCRIPTION
## Summary
This PR implements GitHub Pages hosting for the SocialShareButton demo as requested in #31.

## Changes
- ✅ Added `.github/workflows/deploy-pages.yml` - GitHub Actions workflow for automatic deployment
- ✅ Updated `README.md` with live demo badge and link

## How it works
1. On every push to `main` branch, the workflow automatically deploys the site to GitHub Pages
2. The demo will be accessible at: https://aossie-org.github.io/SocialShareButton/
3. Users can view the live demo without cloning the repo

## Setup Required (After Merge)
The repository maintainer needs to:
1. Go to **Settings** → **Pages**
2. Under **Build and deployment**, select **GitHub Actions** as the source

## Benefits
- 🌐 Users can view a live demo without cloning the repo
- 🧪 Quick testing of styles and configurations
- 📝 Demo link directly accessible from README

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo site now deployed to GitHub Pages with automated deployment workflow.

* **Documentation**
  * README updated with a Live Demo badge/link and revised demo instructions and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->