### PR TITLE
Fix: unregister document-level keydown listener in destroy()

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -301,7 +301,7 @@ class SocialShareButton {
     };
     if (typeof document !== "undefined") {
        document.addEventListener("keydown", this.handleKeydown);
-     
+    }
 
     this.eventsAttached = true; // Mark as attached
   }
@@ -498,7 +498,9 @@ class SocialShareButton {
 
   destroy() {
     if (this.handleKeydown) {
-      document.removeEventListener("keydown", this.handleKeydown);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("keydown", this.handleKeydown);
+      }
       this.handleKeydown = null;
     }
     // Mark as destroyed to prevent async callbacks


### PR DESCRIPTION
#70 fixed 
Previously, attachEvents() registered a document-level keydown
listener using an anonymous function. Because the function
reference was not stored, destroy() could not remove it using
removeEventListener().

This caused event listeners to accumulate when multiple
SocialShareButton instances were created and destroyed,
especially in SPA environments.

Fix:
- Store the keydown handler in this.handleKeydown
- Remove it in destroy()
- Reset the reference to null

This prevents memory leaks and stale listeners.
Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Escape-key handling and lifecycle cleanup for the share/modal UI: the keydown handler is now managed at the component instance level, document listener attachment is guarded to avoid issues in non-browser contexts, and the listener is reliably removed when the component is destroyed. No changes to public APIs or behavior beyond more robust listener management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->