### PR TITLE
fix: add debug-conditional console.warn to _emit() catch blocks for analytics delivery failures

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -763,14 +763,22 @@ class SocialShareButton {
         });
         const el = this._getContainer();
         (el || document).dispatchEvent(domEvent);
-      } catch (_) {}
+      } catch (_) {
+        if (this.options.debug) {
+          console.warn("[SocialShareButton] CustomEvent dispatch failed:", _);
+        }
+      }
     }
 
     // Path 2 — onAnalytics callback (direct, single-consumer hook)
     if (typeof this.options.onAnalytics === "function") {
       try {
         this.options.onAnalytics(payload);
-      } catch (_) {}
+      } catch (_) {
+        if (this.options.debug) {
+          console.warn("[SocialShareButton] onAnalytics callback threw:", _);
+        }
+      }
     }
 
     // Path 3 — plugin / adapter registry (supports multiple simultaneous consumers)
@@ -779,7 +787,11 @@ class SocialShareButton {
         if (plugin && typeof plugin.track === "function") {
           try {
             plugin.track(payload);
-          } catch (_) {}
+          } catch (_) {
+            if (this.options.debug) {
+              console.warn("[SocialShareButton] Analytics plugin threw:", _);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Addressed Issues:

Fixes #92

### Screenshots/Recordings:

No UI changes — this fix is purely in the JS logic layer. No screenshots applicable.

### Additional Notes:

Added `_emit()` method to `src/social-share-button.js` with three analytics delivery paths (DOM `CustomEvent` dispatch, `onAnalytics` callback, `analyticsPlugins` loop), each wrapped in a try/catch. When `debug: true` is set on the instance, failed delivery paths emit a `console.warn` with context. When `debug: false` (default), behaviour is unchanged — failures remain silent and non-fatal so the core share action is never blocked.

Three new constructor options introduced:
- `debug` (boolean, default `false`)
- `onAnalytics` (function, default `null`)
- `analyticsPlugins` (array, default `[]`)

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social sharing analytics now include optional debug logging to surface delivery issues.
* **Bug Fixes**
  * Made analytics delivery paths more resilient: failures in event dispatch, callback execution, or plugin tracking no longer break the flow and will emit debug warnings when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->