### PR TITLE
feat: add Astro, Svelte, and Nuxt.js wrapper components

### DIFF
--- a/src/social-share-button-astro.astro
+++ b/src/social-share-button-astro.astro
@@ -1,0 +1,103 @@
+/**
+ * SocialShareButton Astro Component
+ *
+ * A framework-agnostic wrapper component for Astro that uses the SocialShareButton
+ * vanilla JS library. Works with Astro's client-side hydration.
+ *
+ * Usage:
+ * ---
+ * import SocialShareButton from './components/SocialShareButton.astro';
+ * ---
+ * <SocialShareButton
+ *   url="https://example.com"
+ *   title="My Page"
+ *   description="Check this out!"
+ *   platforms="whatsapp,facebook,twitter"
+ *   client:load
+ * />
+ */
+
+const {
+  url = '',
+  title = '',
+  description = '',
+  hashtags = [],
+  via = '',
+  platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'],
+  theme = 'dark',
+  buttonText = 'Share',
+  customClass = '',
+  buttonStyle = 'default',
+  modalPosition = 'center',
+} = Astro.props;
+
+const hashtagsStr = Array.isArray(hashtags) ? hashtags.join(',') : hashtags;
+const platformsStr = Array.isArray(platforms) ? platforms.join(',') : platforms;
+---
+
+<div
+  class={`social-share-button-astro ${customClass}`}
+  data-url={url}
+  data-title={title}
+  data-description={description}
+  data-hashtags={hashtagsStr}
+  data-via={via}
+  data-platforms={platformsStr}
+  data-theme={theme}
+  data-button-text={buttonText}
+  data-button-style={buttonStyle}
+  data-modal-position={modalPosition}
+></div>
+
+<script>
+  class SocialShareButtonAstro {
+    constructor(element) {
+      this.element = element;
+      this.instance = null;
+      this.init();
+    }
+
+    init() {
+      if (typeof window === 'undefined' || !window.SocialShareButton) {
+        return;
+      }
+
+      const options = {
+        container: this.element,
+        url: this.element.dataset.url || window.location.href,
+        title: this.element.dataset.title || document.title,
+        description: this.element.dataset.description || '',
+        hashtags: this.element.dataset.hashtags
+          ? this.element.dataset.hashtags.split(',').map((t) => t.trim()).filter(Boolean)
+          : [],
+        via: this.element.dataset.via || '',
+        platforms: this.element.dataset.platforms
+          ? this.element.dataset.platforms.split(',').map((p) => p.trim()).filter(Boolean)
+          : ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'],
+        theme: this.element.dataset.theme || 'dark',
+        buttonText: this.element.dataset.buttonText || 'Share',
+        buttonStyle: this.element.dataset.buttonStyle || 'default',
+        modalPosition: this.element.dataset.modalPosition || 'center',
+      };
+
+      this.instance = new window.SocialShareButton(options);
+    }
+
+    destroy() {
+      if (this.instance && typeof this.instance.destroy === 'function') {
+        this.instance.destroy();
+        this.instance = null;
+      }
+    }
+  }
+
+  document.querySelectorAll('.social-share-button-astro').forEach((element) => {
+    new SocialShareButtonAstro(element);
+  });
+
+  document.addEventListener('astro:page-load', () => {
+    document.querySelectorAll('.social-share-button-astro').forEach((element) => {
+      new SocialShareButtonAstro(element);
+    });
+  });
+</script>

--- a/src/social-share-button-astro.astro
+++ b/src/social-share-button-astro.astro
@@ -29,6 +29,9 @@ const {
   customClass = '',
   buttonStyle = 'default',
   modalPosition = 'center',
+  analytics = false,
+  componentId = null,
+  debug = false,
 } = Astro.props;
 
 const hashtagsStr = Array.isArray(hashtags) ? hashtags.join(',') : hashtags;
@@ -47,6 +50,9 @@ const platformsStr = Array.isArray(platforms) ? platforms.join(',') : platforms;
   data-button-text={buttonText}
   data-button-style={buttonStyle}
   data-modal-position={modalPosition}
+  data-analytics={analytics}
+  data-component-id={componentId}
+  data-debug={debug}
 ></div>
 
 <script>
@@ -78,6 +84,9 @@ const platformsStr = Array.isArray(platforms) ? platforms.join(',') : platforms;
         buttonText: this.element.dataset.buttonText || 'Share',
         buttonStyle: this.element.dataset.buttonStyle || 'default',
         modalPosition: this.element.dataset.modalPosition || 'center',
+        analytics: this.element.dataset.analytics === 'true',
+        componentId: this.element.dataset.componentId || null,
+        debug: this.element.dataset.debug === 'true',
       };
 
       this.instance = new window.SocialShareButton(options);

--- a/src/social-share-button-nuxt.vue
+++ b/src/social-share-button-nuxt.vue
@@ -22,6 +22,11 @@ const props = defineProps({
   onCopy: { type: Function, default: null },
   buttonStyle: { type: String, default: 'default' },
   modalPosition: { type: String, default: 'center' },
+  analytics: { type: Boolean, default: false },
+  onAnalytics: { type: Function, default: null },
+  analyticsPlugins: { type: Array, default: () => [] },
+  componentId: { type: String, default: null },
+  debug: { type: Boolean, default: false },
 });
 
 const container = ref(null);
@@ -54,6 +59,11 @@ const initShareButton = () => {
     onCopy: props.onCopy,
     buttonStyle: props.buttonStyle,
     modalPosition: props.modalPosition,
+    analytics: props.analytics,
+    onAnalytics: props.onAnalytics,
+    analyticsPlugins: props.analyticsPlugins,
+    componentId: props.componentId,
+    debug: props.debug,
   });
 };
 

--- a/src/social-share-button-nuxt.vue
+++ b/src/social-share-button-nuxt.vue
@@ -1,0 +1,101 @@
+<template>
+  <div ref="container" :class="`social-share-button-nuxt ${customClass}`"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, watch, computed } from 'vue';
+
+const props = defineProps({
+  url: { type: String, default: '' },
+  title: { type: String, default: '' },
+  description: { type: String, default: '' },
+  hashtags: { type: Array, default: () => [] },
+  via: { type: String, default: '' },
+  platforms: {
+    type: Array,
+    default: () => ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'],
+  },
+  theme: { type: String, default: 'dark' },
+  buttonText: { type: String, default: 'Share' },
+  customClass: { type: String, default: '' },
+  onShare: { type: Function, default: null },
+  onCopy: { type: Function, default: null },
+  buttonStyle: { type: String, default: 'default' },
+  modalPosition: { type: String, default: 'center' },
+});
+
+const container = ref(null);
+let shareButton = null;
+
+const currentUrl = computed(
+  () => props.url || (typeof window !== 'undefined' ? window.location.href : '')
+);
+const currentTitle = computed(
+  () => props.title || (typeof document !== 'undefined' ? document.title : '')
+);
+
+const initShareButton = () => {
+  if (typeof window === 'undefined' || !window.SocialShareButton || !container.value) {
+    return;
+  }
+
+  shareButton = new window.SocialShareButton({
+    container: container.value,
+    url: currentUrl.value,
+    title: currentTitle.value,
+    description: props.description,
+    hashtags: props.hashtags,
+    via: props.via,
+    platforms: props.platforms,
+    theme: props.theme,
+    buttonText: props.buttonText,
+    customClass: props.customClass,
+    onShare: props.onShare,
+    onCopy: props.onCopy,
+    buttonStyle: props.buttonStyle,
+    modalPosition: props.modalPosition,
+  });
+};
+
+const destroyShareButton = () => {
+  if (shareButton && typeof shareButton.destroy === 'function') {
+    shareButton.destroy();
+    shareButton = null;
+  }
+};
+
+onMounted(() => {
+  initShareButton();
+});
+
+onBeforeUnmount(() => {
+  destroyShareButton();
+});
+
+watch(
+  () => [
+    props.url,
+    props.title,
+    props.description,
+    props.hashtags,
+    props.via,
+    props.platforms,
+    props.theme,
+    props.buttonText,
+  ],
+  () => {
+    if (shareButton && typeof shareButton.updateOptions === 'function') {
+      shareButton.updateOptions({
+        url: currentUrl.value,
+        title: currentTitle.value,
+        description: props.description,
+        hashtags: props.hashtags,
+        via: props.via,
+        platforms: props.platforms,
+        theme: props.theme,
+        buttonText: props.buttonText,
+      });
+    }
+  }
+);
+</script>

--- a/src/social-share-button-svelte.svelte
+++ b/src/social-share-button-svelte.svelte
@@ -14,6 +14,11 @@
   export let onCopy = null;
   export let buttonStyle = 'default';
   export let modalPosition = 'center';
+  export let analytics = false;
+  export let onAnalytics = null;
+  export let analyticsPlugins = [];
+  export let componentId = null;
+  export let debug = false;
 
   let container;
   let shareButton = null;
@@ -38,6 +43,11 @@
         onCopy,
         buttonStyle,
         modalPosition,
+        analytics,
+        onAnalytics,
+        analyticsPlugins,
+        componentId,
+        debug,
       });
     }
   });

--- a/src/social-share-button-svelte.svelte
+++ b/src/social-share-button-svelte.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+
+  export let url = '';
+  export let title = '';
+  export let description = '';
+  export let hashtags = [];
+  export let via = '';
+  export let platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'];
+  export let theme = 'dark';
+  export let buttonText = 'Share';
+  export let customClass = '';
+  export let onShare = null;
+  export let onCopy = null;
+  export let buttonStyle = 'default';
+  export let modalPosition = 'center';
+
+  let container;
+  let shareButton = null;
+
+  const currentUrl = url || (typeof window !== 'undefined' ? window.location.href : '');
+  const currentTitle = title || (typeof document !== 'undefined' ? document.title : '');
+
+  onMount(() => {
+    if (typeof window !== 'undefined' && window.SocialShareButton && container) {
+      shareButton = new window.SocialShareButton({
+        container,
+        url: currentUrl,
+        title: currentTitle,
+        description,
+        hashtags,
+        via,
+        platforms,
+        theme,
+        buttonText,
+        customClass,
+        onShare,
+        onCopy,
+        buttonStyle,
+        modalPosition,
+      });
+    }
+  });
+
+  onDestroy(() => {
+    if (shareButton && typeof shareButton.destroy === 'function') {
+      shareButton.destroy();
+      shareButton = null;
+    }
+  });
+</script>
+
+<div bind:this={container} class={`social-share-button-svelte ${customClass}`}></div>


### PR DESCRIPTION
###  Addressed Issues:
Fixes #46, #47, #48

###  Screenshots/Recordings:
N/A (library code only)

###  Additional Notes:
This PR adds native framework wrappers for three popular frameworks:

**Added files:**
1. `src/social-share-button-astro.astro` - Astro component with client-side hydration
2. `src/social-share-button-svelte.svelte` - Svelte/SvelteKit component
3. `src/social-share-button-nuxt.vue` - Nuxt.js/Vue 3 component

**Key features:**
- All wrappers include SSR guards (`typeof window !== 'undefined'`)
- Follow the same pattern as the existing React wrapper
- Support all SocialShareButton options as props
- Proper cleanup on component destruction

**Usage Examples:**

**Astro:**
```astro
---
import SocialShareButton from './components/SocialShareButton.astro';
---
<SocialShareButton url="https://example.com" client:load />
```

**Svelte:**
```svelte
<script>
  import SocialShareButton from './SocialShareButton.svelte';
</script>
<SocialShareButton url="https://example.com" />
```

**Nuxt/Vue:**
```vue
<template>
  <SocialShareButton url="https://example.com" />
</template>
<script setup>
import SocialShareButton from './SocialShareButton.vue';
</script>
```

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## AI Usage Disclosure
- [x] This PR contains AI-generated code. I have read the AI Usage Policy and this PR complies with this policy.