### PR TITLE
feat(remix): add SSR-safe Remix wrapper component and demo section

### DIFF
--- a/.github/copilot/integrate-analytics.prompt.md
+++ b/.github/copilot/integrate-analytics.prompt.md
@@ -41,14 +41,14 @@ forwards to whatever tool they choose.
 
 ## 2 — Core events catalogue
 
-| `eventName`                  | `interactionType` | Fires when                                      |
-| ---------------------------- | ----------------- | ----------------------------------------------- |
-| `social_share_popup_open`    | `popup_open`      | Share modal/popup opens                         |
-| `social_share_popup_close`   | `popup_close`     | Modal closes (button, overlay, or Esc key)      |
-| `social_share_click`         | `share`           | User clicks a platform button (share intent)    |
-| `social_share_success`       | `share`           | Platform share window opened successfully       |
-| `social_share_copy`          | `copy`            | User copies the link to clipboard               |
-| `social_share_error`         | `error`           | Share or copy action failed                     |
+| `eventName`                | `interactionType` | Fires when                                   |
+| -------------------------- | ----------------- | -------------------------------------------- |
+| `social_share_popup_open`  | `popup_open`      | Share modal/popup opens                      |
+| `social_share_popup_close` | `popup_close`     | Modal closes (button, overlay, or Esc key)   |
+| `social_share_click`       | `share`           | User clicks a platform button (share intent) |
+| `social_share_success`     | `share`           | Platform share window opened successfully    |
+| `social_share_copy`        | `copy`            | User copies the link to clipboard            |
+| `social_share_error`       | `error`           | Share or copy action failed                  |
 
 ---
 
@@ -59,7 +59,7 @@ forwards to whatever tool they choose.
 ```js
 // Fires on the container element and bubbles through the DOM (composed:true
 // means it also crosses shadow-DOM boundaries).
-document.addEventListener("social-share", (e) => {
+document.addEventListener('social-share', (e) => {
   const payload = e.detail;
   // Forward to your analytics tool here
 });
@@ -72,7 +72,7 @@ and Mixpanel both need the same event.
 
 ```js
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   onAnalytics: (payload) => {
     // Forward to your analytics tool here
   },
@@ -96,11 +96,8 @@ Load the adapters file **in addition to** the main library script:
 const { GoogleAnalyticsAdapter, MixpanelAdapter } = window.SocialShareAnalytics;
 
 new SocialShareButton({
-  container: "#share-button",
-  analyticsPlugins: [
-    new GoogleAnalyticsAdapter(),
-    new MixpanelAdapter(),
-  ],
+  container: '#share-button',
+  analyticsPlugins: [new GoogleAnalyticsAdapter(), new MixpanelAdapter()],
 });
 ```
 
@@ -125,7 +122,7 @@ Prerequisite: GA4 `gtag.js` snippet loaded by the host.
 const { GoogleAnalyticsAdapter } = window.SocialShareAnalytics;
 
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analyticsPlugins: [new GoogleAnalyticsAdapter()],
 });
 
@@ -135,7 +132,7 @@ new SocialShareButton({
 Custom event category (optional):
 
 ```js
-new GoogleAnalyticsAdapter({ eventCategory: "engagement" })
+new GoogleAnalyticsAdapter({ eventCategory: 'engagement' });
 ```
 
 ### Mixpanel
@@ -145,7 +142,7 @@ Prerequisite: `mixpanel-browser` snippet or SDK loaded.
 ```js
 const { MixpanelAdapter } = window.SocialShareAnalytics;
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analyticsPlugins: [new MixpanelAdapter()],
 });
 // Calls: mixpanel.track(eventName, { platform, url, ... })
@@ -156,7 +153,7 @@ new SocialShareButton({
 ```js
 const { SegmentAdapter } = window.SocialShareAnalytics;
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analyticsPlugins: [new SegmentAdapter()],
 });
 // Calls: analytics.track(eventName, { platform, url, ... })
@@ -169,7 +166,7 @@ Prerequisite: Plausible `script.js` loaded with custom events enabled.
 ```js
 const { PlausibleAdapter } = window.SocialShareAnalytics;
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analyticsPlugins: [new PlausibleAdapter()],
 });
 // Calls: plausible(eventName, { props: { platform, url, ... } })
@@ -180,7 +177,7 @@ new SocialShareButton({
 ```js
 const { PostHogAdapter } = window.SocialShareAnalytics;
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analyticsPlugins: [new PostHogAdapter()],
 });
 // Calls: posthog.capture(eventName, { platform, url, ... })
@@ -195,8 +192,8 @@ const { CustomAdapter } = window.SocialShareAnalytics;
 new SocialShareButton({
   analyticsPlugins: [
     new CustomAdapter((payload) => {
-      fetch("/api/analytics", {
-        method: "POST",
+      fetch('/api/analytics', {
+        method: 'POST',
         body: JSON.stringify(payload),
       });
     }),
@@ -231,17 +228,17 @@ GA4, Mixpanel, and a custom endpoint at the same time:
 ```js
 const { GoogleAnalyticsAdapter, MixpanelAdapter, CustomAdapter } = window.SocialShareAnalytics;
 
-document.addEventListener("social-share", (e) => {
-  console.log("Raw event:", e.detail); // Debugging / logging
+document.addEventListener('social-share', (e) => {
+  console.log('Raw event:', e.detail); // Debugging / logging
 });
 
 new SocialShareButton({
-  container: "#share-button",
-  componentId: "homepage-hero",
+  container: '#share-button',
+  componentId: 'homepage-hero',
   analyticsPlugins: [
     new GoogleAnalyticsAdapter(),
     new MixpanelAdapter(),
-    new CustomAdapter((p) => fetch("/log", { method: "POST", body: JSON.stringify(p) })),
+    new CustomAdapter((p) => fetch('/log', { method: 'POST', body: JSON.stringify(p) })),
   ],
 });
 ```
@@ -255,7 +252,7 @@ development. Remove or set to `false` in production.
 
 ```js
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   debug: true,
   // → [SocialShareButton Analytics] { version: '1.0', source: 'social-share-button', ... }
 });
@@ -271,7 +268,7 @@ instrumentation must be explicitly consented to before activation.
 
 ```js
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   analytics: false,
 });
 ```

--- a/.github/copilot/integrate-social-share-button.prompt.md
+++ b/.github/copilot/integrate-social-share-button.prompt.md
@@ -25,11 +25,11 @@ You are helping a developer integrate the **SocialShareButton** library
 
 The README defines **3 installation methods**. Ask (or infer) which the developer wants:
 
-| Method | When to use |
-|--------|-------------|
-| **Method 1 — CDN (Recommended)** | Most projects. No build step needed. Load via `<script>` tag. |
-| **Method 2 — npm** | Bundler-based projects (Webpack, Vite, etc.) that prefer `import` syntax. |
-| **Method 3 — React Wrapper Component (Optional)** | Developer explicitly wants a reusable JSX component. |
+| Method                                            | When to use                                                               |
+| ------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Method 1 — CDN (Recommended)**                  | Most projects. No build step needed. Load via `<script>` tag.             |
+| **Method 2 — npm**                                | Bundler-based projects (Webpack, Vite, etc.) that prefer `import` syntax. |
+| **Method 3 — React Wrapper Component (Optional)** | Developer explicitly wants a reusable JSX component.                      |
 
 These are **loading methods**, not tech stacks. CDN and npm both work with all frameworks.
 
@@ -39,11 +39,11 @@ These are **loading methods**, not tech stacks. CDN and npm both work with all f
 
 No matter which framework you use, integration always follows the same 3 steps:
 
-| Step | What to do | Where |
-|------|-----------|-------|
-| **1️⃣ Load Library** | Add CSS + JS (CDN links) | Global layout file — `index.html` / `layout.tsx` / `_document.tsx` |
-| **2️⃣ Add Container** | Place `<div id="share-button"></div>` | The UI component where you want the button to appear |
-| **3️⃣ Initialize** | Call `new SocialShareButton({ container: "#share-button" })` | Inside that component, after the DOM is ready (e.g. `useEffect`, `mounted`, `ngAfterViewInit`) |
+| Step                 | What to do                                                   | Where                                                                                          |
+| -------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **1️⃣ Load Library**  | Add CSS + JS (CDN links)                                     | Global layout file — `index.html` / `layout.tsx` / `_document.tsx`                             |
+| **2️⃣ Add Container** | Place `<div id="share-button"></div>`                        | The UI component where you want the button to appear                                           |
+| **3️⃣ Initialize**    | Call `new SocialShareButton({ container: "#share-button" })` | Inside that component, after the DOM is ready (e.g. `useEffect`, `mounted`, `ngAfterViewInit`) |
 
 ---
 
@@ -66,13 +66,16 @@ No framework. Just add the CDN tags directly:
 
 ```html
 <head>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css"
+  />
 </head>
 <body>
   <div id="share-button"></div>
   <script src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.js"></script>
   <script>
-    new SocialShareButton({ container: "#share-button" });
+    new SocialShareButton({ container: '#share-button' });
   </script>
 </body>
 ```
@@ -99,8 +102,8 @@ No framework. Just add the CDN tags directly:
 **Step 2:** Open an **existing** component that renders on every page — typically `src/components/Header.jsx`, `src/layouts/MainLayout.jsx`, or your root `App.jsx`. Add the snippet below to that component so the share button is consistently available across your app.
 
 ```jsx
-import { useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom"; // omit if not using React Router
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom'; // omit if not using React Router
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -113,7 +116,7 @@ function Header() {
     if (initRef.current || !window.SocialShareButton) return;
 
     shareButtonRef.current = new window.SocialShareButton({
-      container: "#share-button",
+      container: '#share-button',
     });
     initRef.current = true;
 
@@ -150,13 +153,9 @@ function Header() {
 **Step 1:** Add CDN to `app/layout.tsx`:
 
 ```tsx
-import Script from "next/script";
+import Script from 'next/script';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
@@ -180,10 +179,10 @@ export default function RootLayout({
 **Step 2:** Because `SocialShareButton` manipulates the DOM, it must run inside a **Client Component** (note the `"use client"` directive at the top). Add the snippet below to an existing component such as `app/components/Header.tsx` or `app/components/Navbar.tsx` — any component already included in your layout.
 
 ```tsx
-"use client";
+'use client';
 
-import { useEffect, useRef } from "react";
-import { usePathname } from "next/navigation";
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -195,11 +194,10 @@ export default function Header() {
 
   useEffect(() => {
     const initButton = () => {
-      if (initRef.current || !window.SocialShareButton || !containerRef.current)
-        return;
+      if (initRef.current || !window.SocialShareButton || !containerRef.current) return;
 
       shareButtonRef.current = new window.SocialShareButton({
-        container: "#share-button",
+        container: '#share-button',
       });
       initRef.current = true;
     };
@@ -262,7 +260,7 @@ declare global {
 **Step 1:** Add CDN to `pages/_document.tsx`:
 
 ```tsx
-import { Html, Head, Main, NextScript } from "next/document";
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
@@ -286,8 +284,8 @@ export default function Document() {
 **Step 2:** Open an existing component that is rendered on every page — typically `components/Header.tsx`, `components/Navbar.tsx`, or `components/Layout.tsx`. Since `_document.tsx` loads the script globally, the button is ready to initialize in any of these components.
 
 ```tsx
-import { useEffect, useRef } from "react";
-import { useRouter } from "next/router";
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -299,11 +297,10 @@ export default function Header() {
 
   useEffect(() => {
     const initButton = () => {
-      if (initRef.current || !window.SocialShareButton || !containerRef.current)
-        return;
+      if (initRef.current || !window.SocialShareButton || !containerRef.current) return;
 
       shareButtonRef.current = new window.SocialShareButton({
-        container: "#share-button",
+        container: '#share-button',
       });
       initRef.current = true;
     };
@@ -384,7 +381,7 @@ declare global {
 // Add <div id="share-button"></div> to your component's template/HTML first,
 // then initialize once the DOM is ready (e.g., in mounted(), ngAfterViewInit(), or useEffect()):
 new window.SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
 });
 ```
 
@@ -395,10 +392,10 @@ new window.SocialShareButton({
 Use when the project has a bundler (Webpack, Vite, etc.) and the developer prefers `import` syntax. Works in any framework.
 
 ```javascript
-import SocialShareButton from "social-share-button-aossie"; 
-import "social-share-button-aossie/src/social-share-button.css";
+import SocialShareButton from 'social-share-button-aossie';
+import 'social-share-button-aossie/src/social-share-button.css';
 
-new SocialShareButton({ container: "#share-button" });
+new SocialShareButton({ container: '#share-button' });
 ```
 
 > No CDN tags needed — the npm package includes both JS and CSS.
@@ -412,10 +409,10 @@ Only use this when the developer **explicitly** wants a reusable JSX component.
 Tell them to copy `src/social-share-button-react.jsx` from the library into their project — **do not create a new file from scratch**.
 
 ```jsx
-import { SocialShareButton } from "./components/SocialShareButton";
+import { SocialShareButton } from './components/SocialShareButton';
 
 function App() {
-  return <SocialShareButton platforms={["twitter", "linkedin"]} />;
+  return <SocialShareButton platforms={['twitter', 'linkedin']} />;
 }
 ```
 
@@ -423,30 +420,30 @@ function App() {
 
 ## All constructor options
 
-| Option             | Type           | Default                | Description                                        |
-| ------------------ | -------------- | ---------------------- | -------------------------------------------------- |
-| `container`        | string/Element | —                      | **Required.** CSS selector or DOM element          |
-| `url`              | string         | `window.location.href` | URL to share                                       |
-| `title`            | string         | `document.title`       | Share title/headline                               |
-| `description`      | string         | `''`                   | Additional description text                        |
-| `hashtags`         | array          | `[]`                   | e.g. `['js', 'webdev']`                            |
-| `via`              | string         | `''`                   | Twitter handle (without @)                         |
+| Option             | Type           | Default                | Description                                                |
+| ------------------ | -------------- | ---------------------- | ---------------------------------------------------------- |
+| `container`        | string/Element | —                      | **Required.** CSS selector or DOM element                  |
+| `url`              | string         | `window.location.href` | URL to share                                               |
+| `title`            | string         | `document.title`       | Share title/headline                                       |
+| `description`      | string         | `''`                   | Additional description text                                |
+| `hashtags`         | array          | `[]`                   | e.g. `['js', 'webdev']`                                    |
+| `via`              | string         | `''`                   | Twitter handle (without @)                                 |
 | `platforms`        | array          | All platforms          | `whatsapp facebook twitter linkedin telegram reddit email` |
-| `buttonText`       | string         | `'Share'`              | Button label text                                  |
-| `buttonStyle`      | string         | `'default'`            | `default` `primary` `compact` `icon-only`          |
-| `buttonColor`      | string         | `''`                   | Custom button background color                     |
-| `buttonHoverColor` | string         | `''`                   | Custom button hover color                          |
-| `customClass`      | string         | `''`                   | Additional CSS class for button                    |
-| `theme`            | string         | `'dark'`               | `dark` or `light`                                  |
-| `modalPosition`    | string         | `'center'`             | Modal position on screen                           |
-| `showButton`       | boolean        | `true`                 | Show/hide the share button                         |
-| `onShare`          | function       | `null`                 | `(platform, url) => void`                          |
-| `onCopy`           | function       | `null`                 | `(url) => void`                                    |
-| `analytics`        | boolean        | `true`                 | Set `false` to disable all event emission          |
-| `onAnalytics`      | function       | `null`                 | `(payload) => void` — direct analytics hook        |
-| `analyticsPlugins` | array          | `[]`                   | Adapter instances from `social-share-analytics.js` |
-| `componentId`      | string         | `null`                 | Label this instance for analytics tracking         |
-| `debug`            | boolean        | `false`                | Log analytics events to console                    |
+| `buttonText`       | string         | `'Share'`              | Button label text                                          |
+| `buttonStyle`      | string         | `'default'`            | `default` `primary` `compact` `icon-only`                  |
+| `buttonColor`      | string         | `''`                   | Custom button background color                             |
+| `buttonHoverColor` | string         | `''`                   | Custom button hover color                                  |
+| `customClass`      | string         | `''`                   | Additional CSS class for button                            |
+| `theme`            | string         | `'dark'`               | `dark` or `light`                                          |
+| `modalPosition`    | string         | `'center'`             | Modal position on screen                                   |
+| `showButton`       | boolean        | `true`                 | Show/hide the share button                                 |
+| `onShare`          | function       | `null`                 | `(platform, url) => void`                                  |
+| `onCopy`           | function       | `null`                 | `(url) => void`                                            |
+| `analytics`        | boolean        | `true`                 | Set `false` to disable all event emission                  |
+| `onAnalytics`      | function       | `null`                 | `(payload) => void` — direct analytics hook                |
+| `analyticsPlugins` | array          | `[]`                   | Adapter instances from `social-share-analytics.js`         |
+| `componentId`      | string         | `null`                 | Label this instance for analytics tracking                 |
+| `debug`            | boolean        | `false`                | Log analytics events to console                            |
 
 ---
 
@@ -469,7 +466,7 @@ const shareButton = useRef(null);
 
 useEffect(() => {
   shareButton.current = new window.SocialShareButton({
-    container: "#share-button",
+    container: '#share-button',
   });
 }, []);
 
@@ -487,25 +484,25 @@ useEffect(() => {
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Multiple buttons appearing | Component re-renders creating duplicate instances | Use `useRef` + `initRef` guard (shown in all examples above) |
-| Button not appearing | Script loads after component renders | Add `if (window.SocialShareButton)` null check |
-| Modal not opening | CSS not loaded or ID mismatch | Verify CSS CDN in `<head>`; match `container: '#share-button'` with `<div id="share-button">` |
-| `TypeError: SocialShareButton is not a constructor` | CDN script not loaded yet | Use interval polling (see Next.js examples above) |
-| URL not updating on navigation | Component initialized once, doesn't track routes | Use `updateOptions()` on route change |
+| Symptom                                             | Cause                                             | Fix                                                                                           |
+| --------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Multiple buttons appearing                          | Component re-renders creating duplicate instances | Use `useRef` + `initRef` guard (shown in all examples above)                                  |
+| Button not appearing                                | Script loads after component renders              | Add `if (window.SocialShareButton)` null check                                                |
+| Modal not opening                                   | CSS not loaded or ID mismatch                     | Verify CSS CDN in `<head>`; match `container: '#share-button'` with `<div id="share-button">` |
+| `TypeError: SocialShareButton is not a constructor` | CDN script not loaded yet                         | Use interval polling (see Next.js examples above)                                             |
+| URL not updating on navigation                      | Component initialized once, doesn't track routes  | Use `updateOptions()` on route change                                                         |
 
 ---
 
 ## Common mistakes to prevent
 
-| ❌ Wrong | ✅ Correct |
-|---------|-----------|
-| Creating `ShareButton.jsx` / `ShareButton.tsx` | Add directly to existing `Header.jsx`, `Navbar.tsx`, etc. |
-| Calling `new SocialShareButton()` inside JSX `return` | Call only inside `useEffect` / lifecycle hook |
-| Not calling `destroy()` on unmount | Always clean up — prevents duplicate modals on re-mount |
-| Mismatched container ID | `container: '#share-button'` must exactly match `<div id="share-button">` |
-| Script loads after component renders in Next.js | Use `strategy="beforeInteractive"` **or** poll with `setInterval` |
+| ❌ Wrong                                              | ✅ Correct                                                                |
+| ----------------------------------------------------- | ------------------------------------------------------------------------- |
+| Creating `ShareButton.jsx` / `ShareButton.tsx`        | Add directly to existing `Header.jsx`, `Navbar.tsx`, etc.                 |
+| Calling `new SocialShareButton()` inside JSX `return` | Call only inside `useEffect` / lifecycle hook                             |
+| Not calling `destroy()` on unmount                    | Always clean up — prevents duplicate modals on re-mount                   |
+| Mismatched container ID                               | `container: '#share-button'` must exactly match `<div id="share-button">` |
+| Script loads after component renders in Next.js       | Use `strategy="beforeInteractive"` **or** poll with `setInterval`         |
 
 ---
 
@@ -516,4 +513,3 @@ useEffect(() => {
 - Always modify **existing** files — never suggest creating new component files.
 - When modifying an existing file, mark additions with `// ADD THIS`.
 - Do not add abstractions, wrappers, or extra files beyond what the README shows.
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <div name="readme-top"></div>
 
-
 > ⚠️ **IMPORTANT**
 >
 > All project discussions happens on **[Discord](https://discord.com/channels/1022871757289422898/1479012884209078365)**.
@@ -73,7 +72,7 @@ Lightweight social sharing component for web applications. Zero dependencies, fr
 
 - 🌐 Multiple platforms: WhatsApp, Facebook, X, LinkedIn, Telegram, Reddit, Email
 - 🎯 Zero dependencies - pure vanilla JavaScript
-- ⚛️ Framework support: React, Next.js, Vue, Angular, or plain HTML
+- ⚛️ Framework support: React, Next.js, Vue, Angular, Remix, or plain HTML
 - 🔄 Auto-detects current URL and page title
 - 📱 Fully responsive and mobile-ready
 - 🎨 Customizable themes (dark/light)
@@ -86,7 +85,10 @@ Lightweight social sharing component for web applications. Zero dependencies, fr
 ### Via CDN (Recommended)
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css">
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css"
+/>
 <script src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.js"></script>
 ```
 
@@ -101,11 +103,11 @@ Lightweight social sharing component for web applications. Zero dependencies, fr
 
 No matter which framework you use, integration always follows the same 3 steps:
 
-| Step | What to do | Where |
-|------|-----------|-------|
-| **1️⃣ Load Library** | Add CSS + JS (CDN links) | Global layout file — `index.html` / `layout.tsx` / `_document.tsx` |
-| **2️⃣ Add Container** | Place `<div id="share-button"></div>` | The UI component where you want the button to appear |
-| **3️⃣ Initialize** | Call `new SocialShareButton({ container: "#share-button" })` | Inside that component, after the DOM is ready (e.g. `useEffect`, `mounted`, `ngAfterViewInit`) |
+| Step                 | What to do                                                   | Where                                                                                          |
+| -------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **1️⃣ Load Library**  | Add CSS + JS (CDN links)                                     | Global layout file — `index.html` / `layout.tsx` / `_document.tsx`                             |
+| **2️⃣ Add Container** | Place `<div id="share-button"></div>`                        | The UI component where you want the button to appear                                           |
+| **3️⃣ Initialize**    | Call `new SocialShareButton({ container: "#share-button" })` | Inside that component, after the DOM is ready (e.g. `useEffect`, `mounted`, `ngAfterViewInit`) |
 
 > 💡 Pick your framework below for the full copy-paste snippet:
 
@@ -132,8 +134,8 @@ No matter which framework you use, integration always follows the same 3 steps:
 Open an **existing** component that renders on every page — typically `src/components/Header.jsx`, `src/layouts/MainLayout.jsx`, or your root `App.jsx`. Add the snippet below to that component so the share button is consistently available across your app.
 
 ```jsx
-import { useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom"; // omit if not using React Router
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom'; // omit if not using React Router
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -146,7 +148,7 @@ function Header() {
     if (initRef.current || !window.SocialShareButton) return;
 
     shareButtonRef.current = new window.SocialShareButton({
-      container: "#share-button",
+      container: '#share-button',
     });
     initRef.current = true;
 
@@ -184,13 +186,9 @@ function Header() {
 ### Step 1: Add CDN to `app/layout.tsx`
 
 ```tsx
-import Script from "next/script";
+import Script from 'next/script';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
@@ -216,10 +214,10 @@ export default function RootLayout({
 Because `SocialShareButton` manipulates the DOM, it must run inside a **Client Component** (note the `"use client"` directive at the top). Add the snippet below to an existing component such as `app/components/Header.tsx` or `app/components/Navbar.tsx` — any component already included in your layout.
 
 ```tsx
-"use client";
+'use client';
 
-import { useEffect, useRef } from "react";
-import { usePathname } from "next/navigation";
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -231,11 +229,10 @@ export default function Header() {
 
   useEffect(() => {
     const initButton = () => {
-      if (initRef.current || !window.SocialShareButton || !containerRef.current)
-        return;
+      if (initRef.current || !window.SocialShareButton || !containerRef.current) return;
 
       shareButtonRef.current = new window.SocialShareButton({
-        container: "#share-button",
+        container: '#share-button',
       });
       initRef.current = true;
     };
@@ -299,7 +296,7 @@ declare global {
 ### Step 1: Add CDN to `pages/_document.tsx`
 
 ```tsx
-import { Html, Head, Main, NextScript } from "next/document";
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
@@ -325,8 +322,8 @@ export default function Document() {
 Open an existing component that is rendered on every page — typically `components/Header.tsx`, `components/Navbar.tsx`, or `components/Layout.tsx`. Since `_document.tsx` loads the script globally, the button is ready to initialize in any of these components.
 
 ```tsx
-import { useEffect, useRef } from "react";
-import { useRouter } from "next/router";
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 
 // ⬇️ Replace 'Header' with the name of the component where you want the
 // share button to appear — e.g. Navbar, MainLayout, App, etc.
@@ -338,11 +335,10 @@ export default function Header() {
 
   useEffect(() => {
     const initButton = () => {
-      if (initRef.current || !window.SocialShareButton || !containerRef.current)
-        return;
+      if (initRef.current || !window.SocialShareButton || !containerRef.current) return;
 
       shareButtonRef.current = new window.SocialShareButton({
-        container: "#share-button",
+        container: '#share-button',
       });
       initRef.current = true;
     };
@@ -426,7 +422,7 @@ Open your root or layout component (e.g., `App.vue`, `app.component.html`, or `A
 // Add <div id="share-button"></div> to your component's template/HTML first,
 // then initialize once the DOM is ready (e.g., in mounted(), ngAfterViewInit(), or useEffect()):
 new window.SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
 });
 ```
 
@@ -440,13 +436,13 @@ new window.SocialShareButton({
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button", // Required: CSS selector or DOM element
-  url: "https://example.com", // Optional: defaults to window.location.href
-  title: "Custom Title", // Optional: defaults to document.title
-  buttonText: "Share", // Optional: button label text
-  buttonStyle: "primary", // default | primary | compact | icon-only
-  theme: "dark", // dark | light
-  platforms: ["twitter", "linkedin"], // Optional: defaults to all platforms
+  container: '#share-button', // Required: CSS selector or DOM element
+  url: 'https://example.com', // Optional: defaults to window.location.href
+  title: 'Custom Title', // Optional: defaults to document.title
+  buttonText: 'Share', // Optional: button label text
+  buttonStyle: 'primary', // default | primary | compact | icon-only
+  theme: 'dark', // dark | light
+  platforms: ['twitter', 'linkedin'], // Optional: defaults to all platforms
 });
 ```
 
@@ -481,12 +477,12 @@ Control the text that appears when users share to social platforms:
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
-  url: "https://myproject.com",
-  title: "Check out my awesome project!", // Main title/headline
-  description: "An amazing tool for developers", // Additional description
-  hashtags: ["javascript", "webdev", "opensource"], // Hashtags included in posts
-  via: "MyProjectHandle", // Your Twitter handle
+  container: '#share-button',
+  url: 'https://myproject.com',
+  title: 'Check out my awesome project!', // Main title/headline
+  description: 'An amazing tool for developers', // Additional description
+  hashtags: ['javascript', 'webdev', 'opensource'], // Hashtags included in posts
+  via: 'MyProjectHandle', // Your Twitter handle
 });
 ```
 
@@ -506,8 +502,8 @@ new SocialShareButton({
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
-  buttonStyle: "primary", // or 'default', 'compact', 'icon-only'
+  container: '#share-button',
+  buttonStyle: 'primary', // or 'default', 'compact', 'icon-only'
 });
 ```
 
@@ -517,9 +513,9 @@ Pass `buttonColor` and `buttonHoverColor` to match your project's color scheme:
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
-  buttonColor: "#ff6b6b", // Button background color
-  buttonHoverColor: "#ff5252", // Hover state color
+  container: '#share-button',
+  buttonColor: '#ff6b6b', // Button background color
+  buttonHoverColor: '#ff5252', // Hover state color
 });
 ```
 
@@ -529,9 +525,9 @@ For more complex styling, use a custom CSS class:
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
-  buttonStyle: "primary",
-  customClass: "my-custom-button",
+  container: '#share-button',
+  buttonStyle: 'primary',
+  customClass: 'my-custom-button',
 });
 ```
 
@@ -555,23 +551,23 @@ Then in your CSS file:
 ```jsx
 // Material Design Red
 new SocialShareButton({
-  container: "#share-button",
-  buttonColor: "#f44336",
-  buttonHoverColor: "#da190b",
+  container: '#share-button',
+  buttonColor: '#f44336',
+  buttonHoverColor: '#da190b',
 });
 
 // Tailwind Blue
 new SocialShareButton({
-  container: "#share-button",
-  buttonColor: "#3b82f6",
-  buttonHoverColor: "#2563eb",
+  container: '#share-button',
+  buttonColor: '#3b82f6',
+  buttonHoverColor: '#2563eb',
 });
 
 // Custom Brand Color
 new SocialShareButton({
-  container: "#share-button",
-  buttonColor: "#your-brand-color",
-  buttonHoverColor: "#your-brand-color-dark",
+  container: '#share-button',
+  buttonColor: '#your-brand-color',
+  buttonHoverColor: '#your-brand-color-dark',
 });
 ```
 
@@ -588,12 +584,12 @@ new SocialShareButton({
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
   onShare: (platform, url) => {
     console.log(`Shared on ${platform}: ${url}`);
   },
   onCopy: (url) => {
-    console.log("Link copied:", url);
+    console.log('Link copied:', url);
   },
 });
 ```
@@ -605,11 +601,11 @@ new SocialShareButton({
 ### Using npm Package
 
 ```javascript
-import SocialShareButton from "social-share-button-aossie";
-import "social-share-button-aossie/src/social-share-button.css";
+import SocialShareButton from 'social-share-button-aossie';
+import 'social-share-button-aossie/src/social-share-button.css';
 
 new SocialShareButton({
-  container: "#share-button",
+  container: '#share-button',
 });
 ```
 
@@ -618,10 +614,10 @@ new SocialShareButton({
 If you want a reusable React component, copy `src/social-share-button-react.jsx` to your project:
 
 ```jsx
-import { SocialShareButton } from "./components/SocialShareButton";
+import { SocialShareButton } from './components/SocialShareButton';
 
 function App() {
-  return <SocialShareButton platforms={["twitter", "linkedin"]} />;
+  return <SocialShareButton platforms={['twitter', 'linkedin']} />;
 }
 ```
 
@@ -640,7 +636,7 @@ const shareButton = useRef(null);
 
 useEffect(() => {
   shareButton.current = new window.SocialShareButton({
-    container: "#share-button",
+    container: '#share-button',
   });
 }, []);
 
@@ -676,7 +672,7 @@ useEffect(() => {
 
 ```jsx
 if (window.SocialShareButton) {
-  new window.SocialShareButton({ container: "#share-button" });
+  new window.SocialShareButton({ container: '#share-button' });
 }
 ```
 
@@ -712,6 +708,53 @@ if (window.SocialShareButton) {
 
 </details>
 
+<details>
+<summary><b>🎸 Remix</b></summary>
+
+### Step 1: Load CSS via `links` export and JS via CDN script in `app/root.tsx`
+
+```tsx
+import type { LinksFunction } from '@remix-run/node';
+
+export const links: LinksFunction = () => [
+  {
+    rel: 'stylesheet',
+    href: 'https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css',
+  },
+];
+```
+
+Add the CDN `<script>` tag just before `</body>` in your root component:
+
+```html
+<script src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.js"></script>
+```
+
+### Step 2: Copy `src/social-share-button-remix.jsx` into your project and use it in a route
+
+```tsx
+// app/routes/_index.tsx
+import SocialShareButton from '~/components/social-share-button-remix';
+
+export default function Index() {
+  return (
+    <SocialShareButton
+      url="https://your-website.com"
+      title="Check this out!"
+      description="An amazing website"
+      theme="dark"
+      buttonText="Share"
+    />
+  );
+}
+```
+
+> **Note:** Remix is SSR-first. The component wraps all browser-API calls inside
+> `useEffect` with an `typeof window !== 'undefined'` guard so it renders safely
+> on the server and only initialises `SocialShareButton` in the browser.
+
+</details>
+
 ---
 
 ## Examples
@@ -729,14 +772,14 @@ if (window.SocialShareButton) {
 ```jsx
 // Professional networks only
 new SocialShareButton({
-  container: "#share-button",
-  platforms: ["linkedin", "twitter", "email"],
+  container: '#share-button',
+  platforms: ['linkedin', 'twitter', 'email'],
 });
 
 // Messaging apps only
 new SocialShareButton({
-  container: "#share-button",
-  platforms: ["whatsapp", "telegram"],
+  container: '#share-button',
+  platforms: ['whatsapp', 'telegram'],
 });
 ```
 
@@ -744,9 +787,9 @@ new SocialShareButton({
 
 ```jsx
 new SocialShareButton({
-  container: "#share-button",
-  buttonStyle: "icon-only",
-  theme: "light",
+  container: '#share-button',
+  buttonStyle: 'icon-only',
+  theme: 'light',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,53 @@ new window.SocialShareButton({
 
 </details>
 
+<details>
+<summary><b>🎸 Remix</b></summary>
+
+### Step 1: Load CSS via `links` export and JS via CDN script in `app/root.tsx`
+
+```tsx
+import type { LinksFunction } from '@remix-run/node';
+
+export const links: LinksFunction = () => [
+  {
+    rel: 'stylesheet',
+    href: 'https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css',
+  },
+];
+```
+
+Add the CDN `<script>` tag just before `</body>` in your root component:
+
+```html
+<script src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.js"></script>
+```
+
+### Step 2: Copy `src/social-share-button-remix.jsx` into your project and use it in a route
+
+```tsx
+// app/routes/_index.tsx
+import SocialShareButton from '~/components/social-share-button-remix';
+
+export default function Index() {
+  return (
+    <SocialShareButton
+      url="https://your-website.com"
+      title="Check this out!"
+      description="An amazing website"
+      theme="dark"
+      buttonText="Share"
+    />
+  );
+}
+```
+
+> **Note:** Remix is SSR-first. The component wraps all browser-API calls inside
+> `useEffect` with an `typeof window !== 'undefined'` guard so it renders safely
+> on the server and only initialises `SocialShareButton` in the browser.
+
+</details>
+
 ---
 
 ## Configuration
@@ -705,53 +752,6 @@ if (window.SocialShareButton) {
 **Cause:** Component initialized once, doesn't track routes
 
 **Solution:** Use `updateOptions()` method (see Advanced Usage above)
-
-</details>
-
-<details>
-<summary><b>🎸 Remix</b></summary>
-
-### Step 1: Load CSS via `links` export and JS via CDN script in `app/root.tsx`
-
-```tsx
-import type { LinksFunction } from '@remix-run/node';
-
-export const links: LinksFunction = () => [
-  {
-    rel: 'stylesheet',
-    href: 'https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.css',
-  },
-];
-```
-
-Add the CDN `<script>` tag just before `</body>` in your root component:
-
-```html
-<script src="https://cdn.jsdelivr.net/gh/AOSSIE-Org/SocialShareButton@v1.0.3/src/social-share-button.js"></script>
-```
-
-### Step 2: Copy `src/social-share-button-remix.jsx` into your project and use it in a route
-
-```tsx
-// app/routes/_index.tsx
-import SocialShareButton from '~/components/social-share-button-remix';
-
-export default function Index() {
-  return (
-    <SocialShareButton
-      url="https://your-website.com"
-      title="Check this out!"
-      description="An amazing website"
-      theme="dark"
-      buttonText="Share"
-    />
-  );
-}
-```
-
-> **Note:** Remix is SSR-first. The component wraps all browser-API calls inside
-> `useEffect` with an `typeof window !== 'undefined'` guard so it renders safely
-> on the server and only initialises `SocialShareButton` in the browser.
 
 </details>
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -8,12 +8,12 @@
 
 Your audience is already sharing. Give them a button worth clicking.
 
-| What you get | What you skip |
-|---|---|
-| One-line install | Backend servers |
+| What you get           | What you skip               |
+| ---------------------- | --------------------------- |
+| One-line install       | Backend servers             |
 | Works on any framework | Tracking or data collection |
-| Fully customizable | Lock-in or licensing fees |
-| Lightweight & fast | Build step (CDN option) |
+| Fully customizable     | Lock-in or licensing fees   |
+| Lightweight & fast     | Build step (CDN option)     |
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,13 @@
-import js from "@eslint/js";
-import globals from "globals";
+import js from '@eslint/js';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
   {
-    files: ["src/**/*.{js,jsx}"],
+    files: ['src/**/*.{js,jsx}'],
     languageOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -20,15 +20,15 @@ export default [
       },
     },
     rules: {
-      "no-console": "error",
-      "no-unused-vars": ["warn", { "caughtErrorsIgnorePattern": "^_" }],
-      "semi": ["error", "always"],
+      'no-console': 'error',
+      'no-unused-vars': ['warn', { caughtErrorsIgnorePattern: '^_' }],
+      semi: ['error', 'always'],
     },
   },
   {
-    files: ["eslint.config.js", "**/*.config.js"],
+    files: ['eslint.config.js', '**/*.config.js'],
     languageOptions: {
-      sourceType: "module",
+      sourceType: 'module',
       globals: {
         ...globals.node,
       },

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
       <p>Get started in seconds with minimal setup</p>
       
 <div class="code-block">
-  <button class="copy-btn" aria-label="Copy code">Copy</button>
+  <button type="button" class="copy-btn" aria-label="Copy code">Copy</button>
   <span class="copy-status" aria-live="polite" style="position:absolute; left:-9999px;"></span>
   <code>
 &lt;link rel="stylesheet" href="social-share-button.css"&gt;
@@ -419,10 +419,10 @@ new SocialShareButton({
       <p>First-class React support with hooks</p>
       
       <div class="code-block">
-  <button class="copy-btn" aria-label="Copy code">Copy</button>
+  <button type="button" class="copy-btn" aria-label="Copy code">Copy</button>
   <span class="copy-status" aria-live="polite" style="position:absolute; left:-9999px;"></span>
   <code>
-<code>import SocialShareButton from 'social-share-button';
+import SocialShareButton from 'social-share-button';
 
 function App() {
   return (
@@ -450,13 +450,13 @@ function App() {
 
       <p style="font-weight:600;margin-top:16px;">Step 1 — Load the CSS &amp; JS in <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;">app/root.tsx</code></p>
       <div class="code-block">
-        <button class="copy-btn" aria-label="Copy code">Copy</button>
+        <button type="button" class="copy-btn" aria-label="Copy code">Copy</button>
         <span class="copy-status" aria-live="polite" style="position:absolute;left:-9999px;"></span>
         <code>
 // app/root.tsx
 import type { LinksFunction } from "@remix-run/node";
 
-export const links: LinksFunction = () => [
+export const links: LinksFunction = () =&gt; [
   {
     rel: "stylesheet",
     href: "https://cdn.jsdelivr.net/npm/social-share-button/dist/social-share-button.css",
@@ -471,7 +471,7 @@ export const links: LinksFunction = () => [
 
       <p style="font-weight:600;margin-top:16px;">Step 2 — Use the component in a route</p>
       <div class="code-block">
-        <button class="copy-btn" aria-label="Copy code">Copy</button>
+        <button type="button" class="copy-btn" aria-label="Copy code">Copy</button>
         <span class="copy-status" aria-live="polite" style="position:absolute;left:-9999px;"></span>
         <code>
 // app/routes/_index.tsx

--- a/index.html
+++ b/index.html
@@ -438,6 +438,59 @@ function App() {
       </div>
     </div>
 
+    <!-- Remix Integration -->
+    <div class="demo-section">
+      <h2>🎸 Remix Integration</h2>
+      <p>
+        Remix is an SSR-first React framework — all browser APIs must live inside
+        <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;">useEffect</code>.
+        Copy <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;">src/social-share-button-remix.jsx</code>
+        into your project and follow the steps below.
+      </p>
+
+      <p style="font-weight:600;margin-top:16px;">Step 1 — Load the CSS &amp; JS in <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;">app/root.tsx</code></p>
+      <div class="code-block">
+        <button class="copy-btn" aria-label="Copy code">Copy</button>
+        <span class="copy-status" aria-live="polite" style="position:absolute;left:-9999px;"></span>
+        <code>
+// app/root.tsx
+import type { LinksFunction } from "@remix-run/node";
+
+export const links: LinksFunction = () => [
+  {
+    rel: "stylesheet",
+    href: "https://cdn.jsdelivr.net/npm/social-share-button/dist/social-share-button.css",
+  },
+];
+
+// In the &lt;head&gt; of your root component, add:
+// &lt;Scripts /&gt; loads the Remix client bundle.
+// Place the CDN &lt;script&gt; just before &lt;/body&gt;:
+// &lt;script src="https://cdn.jsdelivr.net/npm/social-share-button/dist/social-share-button.js"&gt;&lt;/script&gt;</code>
+      </div>
+
+      <p style="font-weight:600;margin-top:16px;">Step 2 — Use the component in a route</p>
+      <div class="code-block">
+        <button class="copy-btn" aria-label="Copy code">Copy</button>
+        <span class="copy-status" aria-live="polite" style="position:absolute;left:-9999px;"></span>
+        <code>
+// app/routes/_index.tsx
+import SocialShareButton from "~/components/social-share-button-remix";
+
+export default function Index() {
+  return (
+    &lt;SocialShareButton
+      url="https://your-website.com"
+      title="Check this out!"
+      description="An amazing website"
+      theme="dark"
+      buttonText="Share"
+    /&gt;
+  );
+}</code>
+      </div>
+    </div>
+
     <!-- CTA Section -->
     <div class="cta-section">
       <h2 style="color: #fff; margin-bottom: 20px;">Ready to Get Started?</h2>

--- a/src/social-share-analytics.js
+++ b/src/social-share-analytics.js
@@ -123,14 +123,14 @@ class GoogleAnalyticsAdapter extends SocialShareAnalyticsPlugin {
    */
   constructor(config = {}) {
     super();
-    this.eventCategory = config.eventCategory || "social_share";
+    this.eventCategory = config.eventCategory || 'social_share';
   }
 
   track(payload) {
-    if (typeof window === "undefined" || typeof window.gtag !== "function") {
+    if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
       return;
     }
-    window.gtag("event", payload.eventName, {
+    window.gtag('event', payload.eventName, {
       event_category: this.eventCategory,
       event_label: payload.platform,
       share_platform: payload.platform,
@@ -151,9 +151,9 @@ class GoogleAnalyticsAdapter extends SocialShareAnalyticsPlugin {
 class MixpanelAdapter extends SocialShareAnalyticsPlugin {
   track(payload) {
     if (
-      typeof window === "undefined" ||
-      typeof window.mixpanel === "undefined" ||
-      typeof window.mixpanel.track !== "function"
+      typeof window === 'undefined' ||
+      typeof window.mixpanel === 'undefined' ||
+      typeof window.mixpanel.track !== 'function'
     ) {
       return;
     }
@@ -177,9 +177,9 @@ class MixpanelAdapter extends SocialShareAnalyticsPlugin {
 class SegmentAdapter extends SocialShareAnalyticsPlugin {
   track(payload) {
     if (
-      typeof window === "undefined" ||
-      typeof window.analytics === "undefined" ||
-      typeof window.analytics.track !== "function"
+      typeof window === 'undefined' ||
+      typeof window.analytics === 'undefined' ||
+      typeof window.analytics.track !== 'function'
     ) {
       return;
     }
@@ -201,7 +201,7 @@ class SegmentAdapter extends SocialShareAnalyticsPlugin {
 // -----------------------------------------------------------------------------
 class PlausibleAdapter extends SocialShareAnalyticsPlugin {
   track(payload) {
-    if (typeof window === "undefined" || typeof window.plausible !== "function") {
+    if (typeof window === 'undefined' || typeof window.plausible !== 'function') {
       return;
     }
     window.plausible(payload.eventName, {
@@ -223,9 +223,9 @@ class PlausibleAdapter extends SocialShareAnalyticsPlugin {
 class PostHogAdapter extends SocialShareAnalyticsPlugin {
   track(payload) {
     if (
-      typeof window === "undefined" ||
-      typeof window.posthog === "undefined" ||
-      typeof window.posthog.capture !== "function"
+      typeof window === 'undefined' ||
+      typeof window.posthog === 'undefined' ||
+      typeof window.posthog.capture !== 'function'
     ) {
       return;
     }
@@ -256,8 +256,8 @@ class CustomAdapter extends SocialShareAnalyticsPlugin {
    */
   constructor(onTrack) {
     super();
-    if (typeof onTrack !== "function") {
-      throw new TypeError("CustomAdapter expects a function argument.");
+    if (typeof onTrack !== 'function') {
+      throw new TypeError('CustomAdapter expects a function argument.');
     }
     this._onTrack = onTrack;
   }
@@ -281,10 +281,10 @@ const adapters = {
   CustomAdapter,
 };
 
-if (typeof module !== "undefined" && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = adapters;
 }
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   window.SocialShareAnalytics = adapters;
 }

--- a/src/social-share-button-react.jsx
+++ b/src/social-share-button-react.jsx
@@ -1,46 +1,37 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef } from 'react';
 
 export const SocialShareButton = ({
   url,
   title,
-  description = "",
+  description = '',
   hashtags = [],
-  via = "",
-  platforms = [
-    "whatsapp",
-    "facebook",
-    "twitter",
-    "linkedin",
-    "telegram",
-    "reddit",
-  ],
-  theme = "dark",
-  buttonText = "Share",
-  customClass = "",
+  via = '',
+  platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'],
+  theme = 'dark',
+  buttonText = 'Share',
+  customClass = '',
   onShare = null,
   onCopy = null,
-  buttonStyle = "default",
-  modalPosition = "center",
+  buttonStyle = 'default',
+  modalPosition = 'center',
   // Analytics props — the library itself never collects data.
   // Provide any combination to connect your own analytics tools.
-  analytics = true,        // set to false to disable all event emission
-  onAnalytics = null,      // (payload) => void — direct callback hook
-  analyticsPlugins = [],   // array of adapter instances (see social-share-analytics.js)
-  componentId = null,      // optional string identifier for this instance
-  debug = false,           // log events to console during development
+  analytics = true, // set to false to disable all event emission
+  onAnalytics = null, // (payload) => void — direct callback hook
+  analyticsPlugins = [], // array of adapter instances (see social-share-analytics.js)
+  componentId = null, // optional string identifier for this instance
+  debug = false, // log events to console during development
 }) => {
   const containerRef = useRef(null);
   const shareButtonRef = useRef(null);
 
   // Auto-detect current URL and title if not provided
-  const currentUrl =
-    url || (typeof window !== "undefined" ? window.location.href : "");
-  const currentTitle =
-    title || (typeof document !== "undefined" ? document.title : "");
+  const currentUrl = url || (typeof window !== 'undefined' ? window.location.href : '');
+  const currentTitle = title || (typeof document !== 'undefined' ? document.title : '');
 
   useEffect(() => {
     if (containerRef.current && !shareButtonRef.current) {
-      if (typeof window !== "undefined" && window.SocialShareButton) {
+      if (typeof window !== 'undefined' && window.SocialShareButton) {
         shareButtonRef.current = new window.SocialShareButton({
           container: containerRef.current,
           url: currentUrl,

--- a/src/social-share-button-remix.jsx
+++ b/src/social-share-button-remix.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * SocialShareButton — Remix-compatible React component.
+ *
+ * Remix is SSR-first and has no `'use client'` directive, so all browser-API
+ * access must be gated inside a `useEffect` hook.  This component:
+ *   1. Initialises the vanilla `window.SocialShareButton` in the first effect
+ *      (runs only in the browser, never on the server).
+ *   2. Calls `destroy()` on unmount to prevent memory leaks.
+ *   3. Calls `updateOptions()` whenever any prop changes so the button always
+ *      reflects the current route URL / page title without a full re-mount.
+ *
+ * @example
+ * // app/routes/_index.tsx
+ * import SocialShareButton from '~/components/social-share-button-remix';
+ *
+ * export default function Index() {
+ *   return (
+ *     <SocialShareButton
+ *       url="https://your-website.com"
+ *       title="Check this out!"
+ *       description="An amazing website"
+ *       theme="dark"
+ *       buttonText="Share"
+ *     />
+ *   );
+ * }
+ */
+export default function SocialShareButton({
+  url = '',
+  title = '',
+  description = '',
+  hashtags = [],
+  via = '',
+  platforms = ['whatsapp', 'facebook', 'twitter', 'linkedin', 'telegram', 'reddit'],
+  theme = 'dark',
+  buttonText = 'Share',
+  customClass = '',
+  onShare = null,
+  onCopy = null,
+  buttonStyle = 'default',
+  modalPosition = 'center',
+}) {
+  const containerRef = useRef(null);
+  const shareButtonRef = useRef(null);
+
+  // ── Mount: initialise once in the browser ──────────────────────────────
+  useEffect(() => {
+    // SSR guard — Remix always server-renders; browser APIs only available here.
+    if (typeof window === 'undefined' || !window.SocialShareButton) return;
+
+    shareButtonRef.current = new window.SocialShareButton({
+      container: containerRef.current,
+      url: url || window.location.href,
+      title: title || document.title,
+      description,
+      hashtags,
+      via,
+      platforms,
+      theme,
+      buttonText,
+      customClass,
+      onShare,
+      onCopy,
+      buttonStyle,
+      modalPosition,
+    });
+
+    // Cleanup on unmount
+    return () => {
+      if (shareButtonRef.current) {
+        shareButtonRef.current.destroy();
+        shareButtonRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Prop updates: keep the button in sync without re-mounting ──────────
+  useEffect(() => {
+    if (!shareButtonRef.current) return;
+
+    shareButtonRef.current.updateOptions({
+      url,
+      title,
+      description,
+      hashtags,
+      via,
+      platforms,
+      theme,
+      buttonText,
+      customClass,
+      onShare,
+      onCopy,
+      buttonStyle,
+      modalPosition,
+    });
+  }, [
+    url,
+    title,
+    description,
+    hashtags,
+    via,
+    platforms,
+    theme,
+    buttonText,
+    customClass,
+    onShare,
+    onCopy,
+    buttonStyle,
+    modalPosition,
+  ]);
+
+  return <div ref={containerRef}></div>;
+}

--- a/src/social-share-button-remix.jsx
+++ b/src/social-share-button-remix.jsx
@@ -41,9 +41,17 @@ export default function SocialShareButton({
   onCopy = null,
   buttonStyle = 'default',
   modalPosition = 'center',
+  analytics = false,
+  onAnalytics = null,
+  analyticsPlugins = [],
+  componentId = null,
+  debug = false,
 }) {
   const containerRef = useRef(null);
   const shareButtonRef = useRef(null);
+
+  const currentUrl = url || (typeof window !== 'undefined' ? window.location.href : '');
+  const currentTitle = title || (typeof document !== 'undefined' ? document.title : '');
 
   // ── Mount: initialise once in the browser ──────────────────────────────
   useEffect(() => {
@@ -52,8 +60,8 @@ export default function SocialShareButton({
 
     shareButtonRef.current = new window.SocialShareButton({
       container: containerRef.current,
-      url: url || window.location.href,
-      title: title || document.title,
+      url: currentUrl,
+      title: currentTitle,
       description,
       hashtags,
       via,
@@ -65,6 +73,11 @@ export default function SocialShareButton({
       onCopy,
       buttonStyle,
       modalPosition,
+      analytics,
+      onAnalytics,
+      analyticsPlugins,
+      componentId,
+      debug,
     });
 
     // Cleanup on unmount
@@ -74,7 +87,6 @@ export default function SocialShareButton({
         shareButtonRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ── Prop updates: keep the button in sync without re-mounting ──────────
@@ -82,8 +94,8 @@ export default function SocialShareButton({
     if (!shareButtonRef.current) return;
 
     shareButtonRef.current.updateOptions({
-      url,
-      title,
+      url: currentUrl,
+      title: currentTitle,
       description,
       hashtags,
       via,
@@ -95,10 +107,15 @@ export default function SocialShareButton({
       onCopy,
       buttonStyle,
       modalPosition,
+      analytics,
+      onAnalytics,
+      analyticsPlugins,
+      componentId,
+      debug,
     });
   }, [
-    url,
-    title,
+    currentUrl,
+    currentTitle,
     description,
     hashtags,
     via,
@@ -110,6 +127,11 @@ export default function SocialShareButton({
     onCopy,
     buttonStyle,
     modalPosition,
+    analytics,
+    onAnalytics,
+    analyticsPlugins,
+    componentId,
+    debug,
   ]);
 
   return <div ref={containerRef}></div>;

--- a/src/social-share-button.css
+++ b/src/social-share-button.css
@@ -19,8 +19,7 @@
   cursor: pointer;
   transition: all 0.3s ease;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   outline: none;
 }
 
@@ -262,8 +261,7 @@
   text-align: center;
   max-width: 80px;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 }
 
 .social-share-modal-overlay.light .social-share-platform-btn span {
@@ -299,8 +297,7 @@
   font-size: 14px;
   outline: none;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 }
 
 .social-share-modal-overlay.light .social-share-link-input input {
@@ -324,8 +321,7 @@
   transition: all 0.2s ease;
   min-width: 80px;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   outline: none;
 }
 

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -5,39 +5,35 @@
  */
 
 /** Analytics event schema version. Increment when the payload shape changes. */
-const ANALYTICS_SCHEMA_VERSION = "1.0";
+const ANALYTICS_SCHEMA_VERSION = '1.0';
 
 class SocialShareButton {
   constructor(options = {}) {
     this.options = {
-      url:
-        options.url ||
-        (typeof window !== "undefined" ? window.location.href : ""),
-      title:
-        options.title ||
-        (typeof document !== "undefined" ? document.title : ""),
-      description: options.description || "",
+      url: options.url || (typeof window !== 'undefined' ? window.location.href : ''),
+      title: options.title || (typeof document !== 'undefined' ? document.title : ''),
+      description: options.description || '',
       hashtags: options.hashtags || [],
-      via: options.via || "",
+      via: options.via || '',
       platforms: options.platforms || [
-        "whatsapp",
-        "facebook",
-        "twitter",
-        "linkedin",
-        "telegram",
-        "reddit",
+        'whatsapp',
+        'facebook',
+        'twitter',
+        'linkedin',
+        'telegram',
+        'reddit',
       ],
-      theme: options.theme || "dark",
-      buttonText: options.buttonText || "Share",
-      customClass: options.customClass || "",
-      buttonColor: options.buttonColor || "",
-      buttonHoverColor: options.buttonHoverColor || "",
+      theme: options.theme || 'dark',
+      buttonText: options.buttonText || 'Share',
+      customClass: options.customClass || '',
+      buttonColor: options.buttonColor || '',
+      buttonHoverColor: options.buttonHoverColor || '',
       onShare: options.onShare || null,
       onCopy: options.onCopy || null,
       container: options.container || null,
       showButton: options.showButton !== false,
-      buttonStyle: options.buttonStyle || "default",
-      modalPosition: options.modalPosition || "center",
+      buttonStyle: options.buttonStyle || 'default',
+      modalPosition: options.modalPosition || 'center',
       // Analytics — the library emits events but never collects or sends data itself.
       // Website owners wire up their own analytics tools via these options.
       analytics: options.analytics !== false, // set to false to disable all event emission
@@ -55,13 +51,12 @@ class SocialShareButton {
     this.handleKeydown = null;
     this.listeners = []; // Central registry for all event listeners
 
-    this.openTimeout = null;  // Track setTimeout for openModal animation
+    this.openTimeout = null; // Track setTimeout for openModal animation
     this.closeTimeout = null; // Track setTimeout for closeModal animation
     this.feedbackTimeout = null; // Track setTimeout for copy feedback reset
     this.ownsBodyLock = false; // Track if this instance owns the body overflow lock
     this.eventsAttached = false; // Guard against multiple attachEvents() calls
     this.isDestroyed = false; // Track if instance has been destroyed (prevents async callbacks)
-
 
     if (this.options.container) {
       this.init();
@@ -78,9 +73,9 @@ class SocialShareButton {
   }
 
   createButton() {
-    const button = document.createElement("button");
+    const button = document.createElement('button');
     button.className = `social-share-btn ${this.options.buttonStyle} ${this.options.customClass}`;
-    button.setAttribute("aria-label", "Share");
+    button.setAttribute('aria-label', 'Share');
     button.innerHTML = `
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="share-icon">
         <path d="M18 16.08C17.24 16.08 16.56 16.38 16.04 16.85L8.91 12.7C8.96 12.47 9 12.24 9 12C9 11.76 8.96 11.53 8.91 11.3L15.96 7.19C16.5 7.69 17.21 8 18 8C19.66 8 21 6.66 21 5C21 3.34 19.66 2 18 2C16.34 2 15 3.34 15 5C15 5.24 15.04 5.47 15.09 5.7L8.04 9.81C7.5 9.31 6.79 9 6 9C4.34 9 3 10.34 3 12C3 13.66 4.34 15 6 15C6.79 15 7.5 14.69 8.04 14.19L15.16 18.35C15.11 18.56 15.08 18.78 15.08 19C15.08 20.61 16.39 21.92 18 21.92C19.61 21.92 20.92 20.61 20.92 19C20.92 17.39 19.61 16.08 18 16.08Z" fill="currentColor"/>
@@ -91,7 +86,7 @@ class SocialShareButton {
     this.button = button;
     if (this.options.container) {
       const container =
-        typeof this.options.container === "string"
+        typeof this.options.container === 'string'
           ? document.querySelector(this.options.container)
           : this.options.container;
 
@@ -102,9 +97,9 @@ class SocialShareButton {
   }
 
   createModal() {
-    const modal = document.createElement("div");
+    const modal = document.createElement('div');
     modal.className = `social-share-modal-overlay ${this.options.theme}`;
-    modal.style.display = "none";
+    modal.style.display = 'none';
     modal.innerHTML = `
       <div class="social-share-modal-content ${this.options.modalPosition}">
         <div class="social-share-modal-header">
@@ -122,12 +117,12 @@ class SocialShareButton {
       </div>
     `;
 
-    const urlInputContainer = modal.querySelector(".social-share-link-input");
-    const urlInput = document.createElement("input");
-    urlInput.type = "text";
+    const urlInputContainer = modal.querySelector('.social-share-link-input');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
     urlInput.value = this.options.url;
     urlInput.readOnly = true;
-    urlInput.setAttribute("aria-label", "URL to share");
+    urlInput.setAttribute('aria-label', 'URL to share');
     urlInputContainer.appendChild(urlInput);
 
     this.modal = modal;
@@ -137,38 +132,38 @@ class SocialShareButton {
   getPlatformsHTML() {
     const platforms = {
       whatsapp: {
-        name: "WhatsApp",
-        color: "#25D366",
+        name: 'WhatsApp',
+        color: '#25D366',
         icon: '<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>',
       },
       facebook: {
-        name: "Facebook",
-        color: "#1877F2",
+        name: 'Facebook',
+        color: '#1877F2',
         icon: '<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>',
       },
       twitter: {
-        name: "X",
-        color: "#000000",
+        name: 'X',
+        color: '#000000',
         icon: '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>',
       },
       linkedin: {
-        name: "LinkedIn",
-        color: "#0A66C2",
+        name: 'LinkedIn',
+        color: '#0A66C2',
         icon: '<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>',
       },
       telegram: {
-        name: "Telegram",
-        color: "#0088cc",
+        name: 'Telegram',
+        color: '#0088cc',
         icon: '<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>',
       },
       reddit: {
-        name: "Reddit",
-        color: "#FF4500",
+        name: 'Reddit',
+        color: '#FF4500',
         icon: '<path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/>',
       },
       email: {
-        name: "Email",
-        color: "#7f7f7f",
+        name: 'Email',
+        color: '#7f7f7f',
         icon: '<path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>',
       },
     };
@@ -186,7 +181,7 @@ class SocialShareButton {
           </button>
         `;
       })
-      .join("");
+      .join('');
   }
 
   getShareURL(platform) {
@@ -194,33 +189,28 @@ class SocialShareButton {
     const encodedUrl = encodeURIComponent(url);
     const encodedTitle = encodeURIComponent(title);
     // const encodedDesc = encodeURIComponent(description);
-    const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
+    const hashtagString = hashtags.length ? '#' + hashtags.join(' #') : '';
 
     // Build platform-specific messages with customizable parameters
-    let whatsappMessage,
-      facebookMessage,
-      twitterMessage,
-      telegramMessage,
-      redditTitle,
-      emailBody;
+    let whatsappMessage, facebookMessage, twitterMessage, telegramMessage, redditTitle, emailBody;
 
     // WhatsApp: Casual with emoji
-    whatsappMessage = `\u{1F680} ${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}\n\nLive on the site \u{1F440}\nClean UI, smooth flow \u{2014} worth peeking\n\u{1F447}`;
+    whatsappMessage = `\u{1F680} ${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}\n\nLive on the site \u{1F440}\nClean UI, smooth flow \u{2014} worth peeking\n\u{1F447}`;
 
     // Facebook: Title + Description
-    facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    facebookMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
 
     // Twitter: Title + Description + Hashtags + Via
-    twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
+    twitterMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n' + hashtagString : ''}`;
 
     // Telegram: Casual with emoji
-    telegramMessage = `\u{1F517} ${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}\n\nLive + working\nClean stuff, take a look \u{1F447}`;
+    telegramMessage = `\u{1F517} ${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}\n\nLive + working\nClean stuff, take a look \u{1F447}`;
 
     // Reddit: Title + Description
-    redditTitle = `${title}${description ? " - " + description : ""}`;
+    redditTitle = `${title}${description ? ' - ' + description : ''}`;
 
     // Email: Friendly greeting
-    emailBody = `Hey \u{1F44B}\n\nSharing a clean project I came across:\n${title}${description ? "\n\n" + description : ""}\n\nLive, simple, and usable \u{2014} take a look \u{1F447}`;
+    emailBody = `Hey \u{1F44B}\n\nSharing a clean project I came across:\n${title}${description ? '\n\n' + description : ''}\n\nLive, simple, and usable \u{2014} take a look \u{1F447}`;
 
     const encodedWhatsapp = encodeURIComponent(whatsappMessage);
     const encodedFacebook = encodeURIComponent(facebookMessage);
@@ -232,14 +222,14 @@ class SocialShareButton {
     const urls = {
       whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
       facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
-      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
+      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? '&via=' + encodeURIComponent(via) : ''}`,
       linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
       telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
       reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
       email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
     };
 
-    return urls[platform] || "";
+    return urls[platform] || '';
   }
 
   addEventListener(element, type, handler, options = false) {
@@ -265,7 +255,7 @@ class SocialShareButton {
     // Button click to open modal
     if (this.button) {
       const openModalHandler = () => this.openModal();
-      this.addEventListener(this.button, "click", openModalHandler);
+      this.addEventListener(this.button, 'click', openModalHandler);
     }
 
     // Modal overlay click to close
@@ -274,43 +264,41 @@ class SocialShareButton {
         this.closeModal();
       }
     };
-    this.addEventListener(this.modal, "click", modalClickHandler);
+    this.addEventListener(this.modal, 'click', modalClickHandler);
 
     // Close button
-    const closeBtn = this.modal.querySelector(".social-share-modal-close");
+    const closeBtn = this.modal.querySelector('.social-share-modal-close');
     const closeBtnHandler = () => this.closeModal();
-    this.addEventListener(closeBtn, "click", closeBtnHandler);
+    this.addEventListener(closeBtn, 'click', closeBtnHandler);
 
     // Platform buttons
-    const platformBtns = this.modal.querySelectorAll(
-      ".social-share-platform-btn",
-    );
+    const platformBtns = this.modal.querySelectorAll('.social-share-platform-btn');
     platformBtns.forEach((btn) => {
       const platformHandler = () => {
         const platform = btn.dataset.platform;
         this.share(platform);
       };
-      this.addEventListener(btn, "click", platformHandler);
+      this.addEventListener(btn, 'click', platformHandler);
     });
 
     // Copy button
-    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
+    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
     const copyBtnHandler = () => this.copyLink();
-    this.addEventListener(copyBtn, "click", copyBtnHandler);
+    this.addEventListener(copyBtn, 'click', copyBtnHandler);
 
     // Input click to select
-    const input = this.modal.querySelector(".social-share-link-input input");
+    const input = this.modal.querySelector('.social-share-link-input input');
     const inputSelectHandler = (e) => e.target.select();
-    this.addEventListener(input, "click", inputSelectHandler);
+    this.addEventListener(input, 'click', inputSelectHandler);
 
     // ESC key to close
     this.handleKeydown = (e) => {
-      if (e.key === "Escape" && this.isModalOpen) {
+      if (e.key === 'Escape' && this.isModalOpen) {
         this.closeModal();
       }
     };
-    if (typeof document !== "undefined") {
-       document.addEventListener("keydown", this.handleKeydown);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', this.handleKeydown);
     }
 
     this.eventsAttached = true; // Mark as attached
@@ -320,11 +308,11 @@ class SocialShareButton {
     if (!this.modal) return;
 
     this.isModalOpen = true;
-    this.modal.style.display = "flex";
-    this._emit("social_share_popup_open", "popup_open");
+    this.modal.style.display = 'flex';
+    this._emit('social_share_popup_open', 'popup_open');
 
     // Shared body overflow management: only increment counter if this instance doesn't already own the lock
-    if (typeof document !== "undefined" && document.body) {
+    if (typeof document !== 'undefined' && document.body) {
       if (!this.ownsBodyLock) {
         // Only increment if this instance doesn't already own a lock
         if (SocialShareButton.openModalCount === 0) {
@@ -334,7 +322,7 @@ class SocialShareButton {
         SocialShareButton.openModalCount++;
         this.ownsBodyLock = true; // Mark that this instance owns a lock
       }
-      document.body.style.overflow = "hidden";
+      document.body.style.overflow = 'hidden';
     }
 
     // Clear any pending animations (both open and close to prevent race conditions)
@@ -349,8 +337,9 @@ class SocialShareButton {
 
     // Animate in
     this.openTimeout = setTimeout(() => {
-      if (this.modal) { // Safety check in case destroy() was called
-        this.modal.classList.add("active");
+      if (this.modal) {
+        // Safety check in case destroy() was called
+        this.modal.classList.add('active');
       }
       this.openTimeout = null;
     }, 10);
@@ -359,8 +348,8 @@ class SocialShareButton {
   closeModal() {
     if (!this.modal) return; // Safety check
 
-    this.modal.classList.remove("active");
-    this._emit("social_share_popup_close", "popup_close");
+    this.modal.classList.remove('active');
+    this._emit('social_share_popup_close', 'popup_close');
 
     // Clear any pending animations (both open and close to prevent race conditions)
     if (this.openTimeout) {
@@ -373,12 +362,13 @@ class SocialShareButton {
     }
 
     this.closeTimeout = setTimeout(() => {
-      if (this.modal) { // Safety check in case destroy() was called
+      if (this.modal) {
+        // Safety check in case destroy() was called
         this.isModalOpen = false;
-        this.modal.style.display = "none";
+        this.modal.style.display = 'none';
 
         // Shared body overflow management: only decrement if this instance owns the lock
-        if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
+        if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
           // Decrement counter (guard against negative)
           if (SocialShareButton.openModalCount > 0) {
             SocialShareButton.openModalCount--;
@@ -387,7 +377,7 @@ class SocialShareButton {
 
           // Restore original overflow only when all modals are closed
           if (SocialShareButton.openModalCount === 0) {
-            document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
+            document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
             SocialShareButton.originalBodyOverflow = null;
           }
         }
@@ -400,25 +390,21 @@ class SocialShareButton {
     const shareUrl = this.getShareURL(platform);
 
     if (shareUrl) {
-      this._emit("social_share_click", "share", { platform });
+      this._emit('social_share_click', 'share', { platform });
 
-      if (platform === "email") {
+      if (platform === 'email') {
         window.location.href = shareUrl;
       } else {
-        window.open(
-          shareUrl,
-          "_blank",
-          "noopener,noreferrer,width=600,height=600",
-        );
+        window.open(shareUrl, '_blank', 'noopener,noreferrer,width=600,height=600');
       }
 
-      this._emit("social_share_success", "share", { platform });
+      this._emit('social_share_success', 'share', { platform });
 
       if (this.options.onShare) {
         this.options.onShare(platform, this.options.url);
       }
     } else {
-      this._emit("social_share_error", "error", {
+      this._emit('social_share_error', 'error', {
         platform,
         errorMessage: `No share URL configured for platform: ${platform}`,
       });
@@ -426,8 +412,8 @@ class SocialShareButton {
   }
 
   copyLink() {
-    const input = this.modal.querySelector(".social-share-link-input input");
-    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
+    const input = this.modal.querySelector('.social-share-link-input input');
+    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
 
     // Check if clipboard API is available
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -437,9 +423,9 @@ class SocialShareButton {
           // Guard against async callback after destroy
           if (this.isDestroyed) return;
 
-          copyBtn.textContent = "Copied!";
-          copyBtn.classList.add("copied");
-          this._emit("social_share_copy", "copy");
+          copyBtn.textContent = 'Copied!';
+          copyBtn.classList.add('copied');
+          this._emit('social_share_copy', 'copy');
 
           if (this.options.onCopy) {
             this.options.onCopy(this.options.url);
@@ -453,13 +439,12 @@ class SocialShareButton {
           // Track feedback timeout to prevent callback after destroy
           this.feedbackTimeout = setTimeout(() => {
             if (this.isDestroyed || !copyBtn) return; // Safety check
-            copyBtn.textContent = "Copy";
-            copyBtn.classList.remove("copied");
+            copyBtn.textContent = 'Copy';
+            copyBtn.classList.remove('copied');
             this.feedbackTimeout = null;
           }, 2000);
         })
         .catch(() => {
-
           // Fallback to manual selection
           this.fallbackCopy(input, copyBtn);
         });
@@ -476,11 +461,11 @@ class SocialShareButton {
     try {
       input.select();
       input.setSelectionRange(0, 99999); // For mobile devices
-      document.execCommand("copy");
+      document.execCommand('copy');
 
-      copyBtn.textContent = "Copied!";
-      copyBtn.classList.add("copied");
-      this._emit("social_share_copy", "copy");
+      copyBtn.textContent = 'Copied!';
+      copyBtn.classList.add('copied');
+      this._emit('social_share_copy', 'copy');
 
       if (this.options.onCopy) {
         this.options.onCopy(this.options.url);
@@ -494,12 +479,12 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = "Copy";
-        copyBtn.classList.remove("copied");
+        copyBtn.textContent = 'Copy';
+        copyBtn.classList.remove('copied');
         this.feedbackTimeout = null;
       }, 2000);
     } catch (_err) {
-      copyBtn.textContent = "Failed";
+      copyBtn.textContent = 'Failed';
 
       // Clear any existing feedback timeout
       if (this.feedbackTimeout) {
@@ -509,7 +494,7 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = "Copy";
+        copyBtn.textContent = 'Copy';
         this.feedbackTimeout = null;
       }, 2000);
     }
@@ -517,8 +502,8 @@ class SocialShareButton {
 
   destroy() {
     if (this.handleKeydown) {
-      if (typeof document !== "undefined") {
-        document.removeEventListener("keydown", this.handleKeydown);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('keydown', this.handleKeydown);
       }
       this.handleKeydown = null;
     }
@@ -544,17 +529,11 @@ class SocialShareButton {
 
     // Remove custom color handlers
     if (this.button && this.customColorMouseEnterHandler) {
-      this.button.removeEventListener(
-        "mouseenter",
-        this.customColorMouseEnterHandler,
-      );
+      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
       this.customColorMouseEnterHandler = null;
     }
     if (this.button && this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener(
-        "mouseleave",
-        this.customColorMouseLeaveHandler,
-      );
+      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
       this.customColorMouseLeaveHandler = null;
     }
 
@@ -567,7 +546,7 @@ class SocialShareButton {
     }
 
     // Shared body overflow management: only decrement if this instance owns the lock
-    if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
+    if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
       // Decrement counter (guard against negative)
       if (SocialShareButton.openModalCount > 0) {
         SocialShareButton.openModalCount--;
@@ -576,7 +555,7 @@ class SocialShareButton {
 
       // Restore original overflow only when all modals are closed
       if (SocialShareButton.openModalCount === 0) {
-        document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
+        document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
         SocialShareButton.originalBodyOverflow = null;
       }
     }
@@ -593,14 +572,14 @@ class SocialShareButton {
 
     // Update URL in modal if it exists
     if (this.modal) {
-      const input = this.modal.querySelector(".social-share-link-input input");
+      const input = this.modal.querySelector('.social-share-link-input input');
       if (input) {
         input.value = this.options.url;
       }
     }
 
     // Reapply custom colors if color option changed
-    if ("buttonColor" in options || "buttonHoverColor" in options) {
+    if ('buttonColor' in options || 'buttonHoverColor' in options) {
       this.applyCustomColors();
     }
   }
@@ -609,44 +588,38 @@ class SocialShareButton {
     if (!this.button) return;
 
     // Remove legacy global style tag to prevent cross-instance color bleed.
-    const styleTag = document.getElementById("social-share-custom-colors");
+    const styleTag = document.getElementById('social-share-custom-colors');
     if (styleTag && styleTag.parentNode) {
       styleTag.parentNode.removeChild(styleTag);
     }
 
     if (this.customColorMouseEnterHandler) {
-      this.button.removeEventListener(
-        "mouseenter",
-        this.customColorMouseEnterHandler,
-      );
+      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
       this.customColorMouseEnterHandler = null;
     }
     if (this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener(
-        "mouseleave",
-        this.customColorMouseLeaveHandler,
-      );
+      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
       this.customColorMouseLeaveHandler = null;
     }
 
-    this.button.style.removeProperty("background-color");
-    this.button.style.removeProperty("background-image");
-    this.button.style.removeProperty("border-color");
+    this.button.style.removeProperty('background-color');
+    this.button.style.removeProperty('background-image');
+    this.button.style.removeProperty('border-color');
 
-    const baseColor = this.options.buttonColor || "";
+    const baseColor = this.options.buttonColor || '';
     const hoverColor = this.options.buttonHoverColor || baseColor;
 
     if (!baseColor && !hoverColor) return;
 
     if (baseColor) {
-      this.button.style.backgroundImage = "none";
+      this.button.style.backgroundImage = 'none';
       this.button.style.backgroundColor = baseColor;
       this.button.style.borderColor = baseColor;
     }
 
     this.customColorMouseEnterHandler = () => {
       if (hoverColor) {
-        this.button.style.backgroundImage = "none";
+        this.button.style.backgroundImage = 'none';
         this.button.style.backgroundColor = hoverColor;
         this.button.style.borderColor = hoverColor;
       }
@@ -654,26 +627,20 @@ class SocialShareButton {
 
     this.customColorMouseLeaveHandler = () => {
       if (baseColor) {
-        this.button.style.backgroundImage = "none";
+        this.button.style.backgroundImage = 'none';
         this.button.style.backgroundColor = baseColor;
         this.button.style.borderColor = baseColor;
       } else {
-        this.button.style.removeProperty("background-color");
-        this.button.style.removeProperty("background-image");
-        this.button.style.removeProperty("border-color");
+        this.button.style.removeProperty('background-color');
+        this.button.style.removeProperty('background-image');
+        this.button.style.removeProperty('border-color');
       }
     };
 
     // Note: Custom color handlers are managed separately (not in listeners)
     // because they need to be removed/reapplied when colors change
-    this.button.addEventListener(
-      "mouseenter",
-      this.customColorMouseEnterHandler,
-    );
-    this.button.addEventListener(
-      "mouseleave",
-      this.customColorMouseLeaveHandler,
-    );
+    this.button.addEventListener('mouseenter', this.customColorMouseEnterHandler);
+    this.button.addEventListener('mouseleave', this.customColorMouseLeaveHandler);
   }
 
   // ---------------------------------------------------------------------------
@@ -699,8 +666,8 @@ class SocialShareButton {
    */
   _getContainer() {
     if (!this.options.container) return null;
-    if (typeof document === "undefined") return null;
-    return typeof this.options.container === "string"
+    if (typeof document === 'undefined') return null;
+    return typeof this.options.container === 'string'
       ? document.querySelector(this.options.container)
       : this.options.container;
   }
@@ -731,7 +698,7 @@ class SocialShareButton {
 
     const payload = {
       version: ANALYTICS_SCHEMA_VERSION,
-      source: "social-share-button",
+      source: 'social-share-button',
       eventName,
       interactionType,
       platform: extra.platform || null,
@@ -748,14 +715,14 @@ class SocialShareButton {
     // Optional console output for development / debugging
     if (this.options.debug) {
       // eslint-disable-next-line no-console
-      console.log("[SocialShareButton Analytics]", payload);
+      console.log('[SocialShareButton Analytics]', payload);
     }
 
     // Path 1 — DOM CustomEvent (framework-agnostic, CDN-friendly)
     // Bubbles from the container element so delegated listeners work naturally.
-    if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
+    if (typeof window !== 'undefined' && typeof CustomEvent !== 'undefined') {
       try {
-        const domEvent = new CustomEvent("social-share", {
+        const domEvent = new CustomEvent('social-share', {
           bubbles: true,
           cancelable: false,
           composed: true, // crosses shadow-DOM boundaries; safe to set in all envs
@@ -763,23 +730,29 @@ class SocialShareButton {
         });
         const el = this._getContainer();
         (el || document).dispatchEvent(domEvent);
-      } catch (_) {}
+      } catch (_) {
+        // ignore
+      }
     }
 
     // Path 2 — onAnalytics callback (direct, single-consumer hook)
-    if (typeof this.options.onAnalytics === "function") {
+    if (typeof this.options.onAnalytics === 'function') {
       try {
         this.options.onAnalytics(payload);
-      } catch (_) {}
+      } catch (_) {
+        // ignore
+      }
     }
 
     // Path 3 — plugin / adapter registry (supports multiple simultaneous consumers)
     if (Array.isArray(this.options.analyticsPlugins)) {
       for (const plugin of this.options.analyticsPlugins) {
-        if (plugin && typeof plugin.track === "function") {
+        if (plugin && typeof plugin.track === 'function') {
           try {
             plugin.track(payload);
-          } catch (_) {}
+          } catch (_) {
+            // ignore
+          }
         }
       }
     }
@@ -791,10 +764,10 @@ SocialShareButton.openModalCount = 0;
 SocialShareButton.originalBodyOverflow = null;
 
 // Export for different module systems
-if (typeof module !== "undefined" && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = SocialShareButton;
 }
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   window.SocialShareButton = SocialShareButton;
 }


### PR DESCRIPTION
## Summary

Closes #55

Adds Remix framework support for SocialShareButton.

### Changes

- **`src/social-share-button-remix.jsx`** — New Remix-compatible React component that:
  - Initialises `window.SocialShareButton` inside `useEffect` with an `typeof window !== 'undefined'` SSR guard (Remix always server-renders; no `'use client'` directive exists)
  - Calls `destroy()` on unmount to prevent memory leaks
  - Calls `updateOptions()` in a second effect whenever props change, keeping the button in sync with route navigation without re-mounting
- **`index.html`** — New `🎸 Remix Integration` demo section with two copy-to-clipboard code blocks (step 1: load CSS/JS in `app/root.tsx`; step 2: use the component in a route)
- **`README.md`** — New `<details>` block listing Remix as a supported framework with full copy-paste snippet

### Screenshots / Recordings

<!-- Add a screenshot or screen recording of the Remix section in index.html -->

---

## Checklist

- [x] My changes follow the project's code style
- [x] I have tested the changes locally
- [x] I have updated the documentation (README, index.html)
- [x] No new wrapper introduces new dependencies

---

## AI Usage Disclosure

GitHub Copilot / OpenCode assisted with code generation and formatting. All logic was reviewed and validated manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Remix framework integration with a Remix-compatible component and new analytics hooks (callback/plugins, instance ID, debug)

* **Documentation**
  * Comprehensive Remix integration guide, demo, and troubleshooting added
  * Updated examples and formatting for consistency and readability

* **Bug Fixes / UX**
  * Prevented unintended form submissions by setting demo copy buttons to button type
<!-- end of auto-generated comment: release notes by coderabbit.ai -->