### PR TITLE
fix: remove hardcoded promotional text from share messages

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -5,35 +5,39 @@
  */
 
 /** Analytics event schema version. Increment when the payload shape changes. */
-const ANALYTICS_SCHEMA_VERSION = '1.0';
+const ANALYTICS_SCHEMA_VERSION = "1.0";
 
 class SocialShareButton {
   constructor(options = {}) {
     this.options = {
-      url: options.url || (typeof window !== 'undefined' ? window.location.href : ''),
-      title: options.title || (typeof document !== 'undefined' ? document.title : ''),
-      description: options.description || '',
+      url:
+        options.url ||
+        (typeof window !== "undefined" ? window.location.href : ""),
+      title:
+        options.title ||
+        (typeof document !== "undefined" ? document.title : ""),
+      description: options.description || "",
       hashtags: options.hashtags || [],
-      via: options.via || '',
+      via: options.via || "",
       platforms: options.platforms || [
-        'whatsapp',
-        'facebook',
-        'twitter',
-        'linkedin',
-        'telegram',
-        'reddit',
+        "whatsapp",
+        "facebook",
+        "twitter",
+        "linkedin",
+        "telegram",
+        "reddit",
       ],
-      theme: options.theme || 'dark',
-      buttonText: options.buttonText || 'Share',
-      customClass: options.customClass || '',
-      buttonColor: options.buttonColor || '',
-      buttonHoverColor: options.buttonHoverColor || '',
+      theme: options.theme || "dark",
+      buttonText: options.buttonText || "Share",
+      customClass: options.customClass || "",
+      buttonColor: options.buttonColor || "",
+      buttonHoverColor: options.buttonHoverColor || "",
       onShare: options.onShare || null,
       onCopy: options.onCopy || null,
       container: options.container || null,
       showButton: options.showButton !== false,
-      buttonStyle: options.buttonStyle || 'default',
-      modalPosition: options.modalPosition || 'center',
+      buttonStyle: options.buttonStyle || "default",
+      modalPosition: options.modalPosition || "center",
       // Analytics — the library emits events but never collects or sends data itself.
       // Website owners wire up their own analytics tools via these options.
       analytics: options.analytics !== false, // set to false to disable all event emission
@@ -51,12 +55,13 @@ class SocialShareButton {
     this.handleKeydown = null;
     this.listeners = []; // Central registry for all event listeners
 
-    this.openTimeout = null; // Track setTimeout for openModal animation
+    this.openTimeout = null;  // Track setTimeout for openModal animation
     this.closeTimeout = null; // Track setTimeout for closeModal animation
     this.feedbackTimeout = null; // Track setTimeout for copy feedback reset
     this.ownsBodyLock = false; // Track if this instance owns the body overflow lock
     this.eventsAttached = false; // Guard against multiple attachEvents() calls
     this.isDestroyed = false; // Track if instance has been destroyed (prevents async callbacks)
+
 
     if (this.options.container) {
       this.init();
@@ -73,9 +78,9 @@ class SocialShareButton {
   }
 
   createButton() {
-    const button = document.createElement('button');
+    const button = document.createElement("button");
     button.className = `social-share-btn ${this.options.buttonStyle} ${this.options.customClass}`;
-    button.setAttribute('aria-label', 'Share');
+    button.setAttribute("aria-label", "Share");
     button.innerHTML = `
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="share-icon">
         <path d="M18 16.08C17.24 16.08 16.56 16.38 16.04 16.85L8.91 12.7C8.96 12.47 9 12.24 9 12C9 11.76 8.96 11.53 8.91 11.3L15.96 7.19C16.5 7.69 17.21 8 18 8C19.66 8 21 6.66 21 5C21 3.34 19.66 2 18 2C16.34 2 15 3.34 15 5C15 5.24 15.04 5.47 15.09 5.7L8.04 9.81C7.5 9.31 6.79 9 6 9C4.34 9 3 10.34 3 12C3 13.66 4.34 15 6 15C6.79 15 7.5 14.69 8.04 14.19L15.16 18.35C15.11 18.56 15.08 18.78 15.08 19C15.08 20.61 16.39 21.92 18 21.92C19.61 21.92 20.92 20.61 20.92 19C20.92 17.39 19.61 16.08 18 16.08Z" fill="currentColor"/>
@@ -86,7 +91,7 @@ class SocialShareButton {
     this.button = button;
     if (this.options.container) {
       const container =
-        typeof this.options.container === 'string'
+        typeof this.options.container === "string"
           ? document.querySelector(this.options.container)
           : this.options.container;
 
@@ -97,9 +102,9 @@ class SocialShareButton {
   }
 
   createModal() {
-    const modal = document.createElement('div');
+    const modal = document.createElement("div");
     modal.className = `social-share-modal-overlay ${this.options.theme}`;
-    modal.style.display = 'none';
+    modal.style.display = "none";
     modal.innerHTML = `
       <div class="social-share-modal-content ${this.options.modalPosition}">
         <div class="social-share-modal-header">
@@ -117,12 +122,12 @@ class SocialShareButton {
       </div>
     `;
 
-    const urlInputContainer = modal.querySelector('.social-share-link-input');
-    const urlInput = document.createElement('input');
-    urlInput.type = 'text';
+    const urlInputContainer = modal.querySelector(".social-share-link-input");
+    const urlInput = document.createElement("input");
+    urlInput.type = "text";
     urlInput.value = this.options.url;
     urlInput.readOnly = true;
-    urlInput.setAttribute('aria-label', 'URL to share');
+    urlInput.setAttribute("aria-label", "URL to share");
     urlInputContainer.appendChild(urlInput);
 
     this.modal = modal;
@@ -132,38 +137,38 @@ class SocialShareButton {
   getPlatformsHTML() {
     const platforms = {
       whatsapp: {
-        name: 'WhatsApp',
-        color: '#25D366',
+        name: "WhatsApp",
+        color: "#25D366",
         icon: '<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>',
       },
       facebook: {
-        name: 'Facebook',
-        color: '#1877F2',
+        name: "Facebook",
+        color: "#1877F2",
         icon: '<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>',
       },
       twitter: {
-        name: 'X',
-        color: '#000000',
+        name: "X",
+        color: "#000000",
         icon: '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>',
       },
       linkedin: {
-        name: 'LinkedIn',
-        color: '#0A66C2',
+        name: "LinkedIn",
+        color: "#0A66C2",
         icon: '<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>',
       },
       telegram: {
-        name: 'Telegram',
-        color: '#0088cc',
+        name: "Telegram",
+        color: "#0088cc",
         icon: '<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>',
       },
       reddit: {
-        name: 'Reddit',
-        color: '#FF4500',
+        name: "Reddit",
+        color: "#FF4500",
         icon: '<path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/>',
       },
       email: {
-        name: 'Email',
-        color: '#7f7f7f',
+        name: "Email",
+        color: "#7f7f7f",
         icon: '<path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>',
       },
     };
@@ -181,55 +186,60 @@ class SocialShareButton {
           </button>
         `;
       })
-      .join('');
+      .join("");
   }
 
   getShareURL(platform) {
-    const { url, title, description, hashtags, via } = this.options;
-    const encodedUrl = encodeURIComponent(url);
-    const encodedTitle = encodeURIComponent(title);
-    const hashtagString = hashtags.length ? '#' + hashtags.join(' #') : '';
+  const { url, title, description, hashtags, via } = this.options;
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+  const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
 
-    // Build platform-specific messages with customizable parameters
-    let whatsappMessage, facebookMessage, twitterMessage, telegramMessage, redditTitle, emailBody;
+  // Build platform-specific messages with customizable parameters
+  let whatsappMessage,
+    facebookMessage,
+    twitterMessage,
+    telegramMessage,
+    redditTitle,
+    emailBody;
 
-    // WhatsApp: title + description + hashtags
-    whatsappMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
+  // WhatsApp: title + description + hashtags
+  whatsappMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Facebook: title + description + hashtags
-    facebookMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
+  // Facebook: title + description + hashtags
+  facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Twitter: title + description + hashtags + via
-    twitterMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n' + hashtagString : ''}`;
+  // Twitter: title + description + hashtags + via
+  twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
 
-    // Telegram: title + description + hashtags
-    telegramMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
+  // Telegram: title + description + hashtags
+  telegramMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Reddit: title + description
-    redditTitle = `${title}${description ? ' - ' + description : ''}`;
+  // Reddit: title + description
+  redditTitle = `${title}${description ? " - " + description : ""}`;
 
-    // Email: description in body, title in subject
-    emailBody = `${title}${description ? '\n\n' + description : ''}`;
+  // Email: description in body, title in subject
+  emailBody = `${description ? description : ""}`;
 
-    const encodedWhatsapp = encodeURIComponent(whatsappMessage);
-    const encodedFacebook = encodeURIComponent(facebookMessage);
-    const encodedTwitter = encodeURIComponent(twitterMessage);
-    const encodedTelegram = encodeURIComponent(telegramMessage);
-    const encodedReddit = encodeURIComponent(redditTitle);
-    const encodedEmail = encodeURIComponent(emailBody);
+  const encodedWhatsapp = encodeURIComponent(whatsappMessage);
+  const encodedFacebook = encodeURIComponent(facebookMessage);
+  const encodedTwitter = encodeURIComponent(twitterMessage);
+  const encodedTelegram = encodeURIComponent(telegramMessage);
+  const encodedReddit = encodeURIComponent(redditTitle);
+  const encodedEmail = encodeURIComponent(emailBody);
 
-    const urls = {
-      whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
-      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
-      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? '&via=' + encodeURIComponent(via) : ''}`,
-      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-      telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
-      reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
-      email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
-    };
+  const urls = {
+    whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+    telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
+    reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
+    email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
+  };
 
-    return urls[platform] || '';
-  }
+  return urls[platform] || "";
+}
 
   addEventListener(element, type, handler, options = false) {
     if (!element) return;
@@ -254,7 +264,7 @@ class SocialShareButton {
     // Button click to open modal
     if (this.button) {
       const openModalHandler = () => this.openModal();
-      this.addEventListener(this.button, 'click', openModalHandler);
+      this.addEventListener(this.button, "click", openModalHandler);
     }
 
     // Modal overlay click to close
@@ -263,41 +273,43 @@ class SocialShareButton {
         this.closeModal();
       }
     };
-    this.addEventListener(this.modal, 'click', modalClickHandler);
+    this.addEventListener(this.modal, "click", modalClickHandler);
 
     // Close button
-    const closeBtn = this.modal.querySelector('.social-share-modal-close');
+    const closeBtn = this.modal.querySelector(".social-share-modal-close");
     const closeBtnHandler = () => this.closeModal();
-    this.addEventListener(closeBtn, 'click', closeBtnHandler);
+    this.addEventListener(closeBtn, "click", closeBtnHandler);
 
     // Platform buttons
-    const platformBtns = this.modal.querySelectorAll('.social-share-platform-btn');
+    const platformBtns = this.modal.querySelectorAll(
+      ".social-share-platform-btn",
+    );
     platformBtns.forEach((btn) => {
       const platformHandler = () => {
         const platform = btn.dataset.platform;
         this.share(platform);
       };
-      this.addEventListener(btn, 'click', platformHandler);
+      this.addEventListener(btn, "click", platformHandler);
     });
 
     // Copy button
-    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
+    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
     const copyBtnHandler = () => this.copyLink();
-    this.addEventListener(copyBtn, 'click', copyBtnHandler);
+    this.addEventListener(copyBtn, "click", copyBtnHandler);
 
     // Input click to select
-    const input = this.modal.querySelector('.social-share-link-input input');
+    const input = this.modal.querySelector(".social-share-link-input input");
     const inputSelectHandler = (e) => e.target.select();
-    this.addEventListener(input, 'click', inputSelectHandler);
+    this.addEventListener(input, "click", inputSelectHandler);
 
     // ESC key to close
     this.handleKeydown = (e) => {
-      if (e.key === 'Escape' && this.isModalOpen) {
+      if (e.key === "Escape" && this.isModalOpen) {
         this.closeModal();
       }
     };
-    if (typeof document !== 'undefined') {
-      document.addEventListener('keydown', this.handleKeydown);
+    if (typeof document !== "undefined") {
+       document.addEventListener("keydown", this.handleKeydown);
     }
 
     this.eventsAttached = true; // Mark as attached
@@ -307,11 +319,11 @@ class SocialShareButton {
     if (!this.modal) return;
 
     this.isModalOpen = true;
-    this.modal.style.display = 'flex';
-    this._emit('social_share_popup_open', 'popup_open');
+    this.modal.style.display = "flex";
+    this._emit("social_share_popup_open", "popup_open");
 
     // Shared body overflow management: only increment counter if this instance doesn't already own the lock
-    if (typeof document !== 'undefined' && document.body) {
+    if (typeof document !== "undefined" && document.body) {
       if (!this.ownsBodyLock) {
         // Only increment if this instance doesn't already own a lock
         if (SocialShareButton.openModalCount === 0) {
@@ -321,7 +333,7 @@ class SocialShareButton {
         SocialShareButton.openModalCount++;
         this.ownsBodyLock = true; // Mark that this instance owns a lock
       }
-      document.body.style.overflow = 'hidden';
+      document.body.style.overflow = "hidden";
     }
 
     // Clear any pending animations (both open and close to prevent race conditions)
@@ -336,9 +348,8 @@ class SocialShareButton {
 
     // Animate in
     this.openTimeout = setTimeout(() => {
-      if (this.modal) {
-        // Safety check in case destroy() was called
-        this.modal.classList.add('active');
+      if (this.modal) { // Safety check in case destroy() was called
+        this.modal.classList.add("active");
       }
       this.openTimeout = null;
     }, 10);
@@ -347,8 +358,8 @@ class SocialShareButton {
   closeModal() {
     if (!this.modal) return; // Safety check
 
-    this.modal.classList.remove('active');
-    this._emit('social_share_popup_close', 'popup_close');
+    this.modal.classList.remove("active");
+    this._emit("social_share_popup_close", "popup_close");
 
     // Clear any pending animations (both open and close to prevent race conditions)
     if (this.openTimeout) {
@@ -361,13 +372,12 @@ class SocialShareButton {
     }
 
     this.closeTimeout = setTimeout(() => {
-      if (this.modal) {
-        // Safety check in case destroy() was called
+      if (this.modal) { // Safety check in case destroy() was called
         this.isModalOpen = false;
-        this.modal.style.display = 'none';
+        this.modal.style.display = "none";
 
         // Shared body overflow management: only decrement if this instance owns the lock
-        if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
+        if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
           // Decrement counter (guard against negative)
           if (SocialShareButton.openModalCount > 0) {
             SocialShareButton.openModalCount--;
@@ -376,7 +386,7 @@ class SocialShareButton {
 
           // Restore original overflow only when all modals are closed
           if (SocialShareButton.openModalCount === 0) {
-            document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
+            document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
             SocialShareButton.originalBodyOverflow = null;
           }
         }
@@ -389,21 +399,25 @@ class SocialShareButton {
     const shareUrl = this.getShareURL(platform);
 
     if (shareUrl) {
-      this._emit('social_share_click', 'share', { platform });
+      this._emit("social_share_click", "share", { platform });
 
-      if (platform === 'email') {
+      if (platform === "email") {
         window.location.href = shareUrl;
       } else {
-        window.open(shareUrl, '_blank', 'noopener,noreferrer,width=600,height=600');
+        window.open(
+          shareUrl,
+          "_blank",
+          "noopener,noreferrer,width=600,height=600",
+        );
       }
 
-      this._emit('social_share_success', 'share', { platform });
+      this._emit("social_share_success", "share", { platform });
 
       if (this.options.onShare) {
         this.options.onShare(platform, this.options.url);
       }
     } else {
-      this._emit('social_share_error', 'error', {
+      this._emit("social_share_error", "error", {
         platform,
         errorMessage: `No share URL configured for platform: ${platform}`,
       });
@@ -411,8 +425,8 @@ class SocialShareButton {
   }
 
   copyLink() {
-    const input = this.modal.querySelector('.social-share-link-input input');
-    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
+    const input = this.modal.querySelector(".social-share-link-input input");
+    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
 
     // Check if clipboard API is available
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -422,9 +436,9 @@ class SocialShareButton {
           // Guard against async callback after destroy
           if (this.isDestroyed) return;
 
-          copyBtn.textContent = 'Copied!';
-          copyBtn.classList.add('copied');
-          this._emit('social_share_copy', 'copy');
+          copyBtn.textContent = "Copied!";
+          copyBtn.classList.add("copied");
+          this._emit("social_share_copy", "copy");
 
           if (this.options.onCopy) {
             this.options.onCopy(this.options.url);
@@ -438,12 +452,13 @@ class SocialShareButton {
           // Track feedback timeout to prevent callback after destroy
           this.feedbackTimeout = setTimeout(() => {
             if (this.isDestroyed || !copyBtn) return; // Safety check
-            copyBtn.textContent = 'Copy';
-            copyBtn.classList.remove('copied');
+            copyBtn.textContent = "Copy";
+            copyBtn.classList.remove("copied");
             this.feedbackTimeout = null;
           }, 2000);
         })
         .catch(() => {
+
           // Fallback to manual selection
           this.fallbackCopy(input, copyBtn);
         });
@@ -460,11 +475,11 @@ class SocialShareButton {
     try {
       input.select();
       input.setSelectionRange(0, 99999); // For mobile devices
-      document.execCommand('copy');
+      document.execCommand("copy");
 
-      copyBtn.textContent = 'Copied!';
-      copyBtn.classList.add('copied');
-      this._emit('social_share_copy', 'copy');
+      copyBtn.textContent = "Copied!";
+      copyBtn.classList.add("copied");
+      this._emit("social_share_copy", "copy");
 
       if (this.options.onCopy) {
         this.options.onCopy(this.options.url);
@@ -478,12 +493,12 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = 'Copy';
-        copyBtn.classList.remove('copied');
+        copyBtn.textContent = "Copy";
+        copyBtn.classList.remove("copied");
         this.feedbackTimeout = null;
       }, 2000);
     } catch (_err) {
-      copyBtn.textContent = 'Failed';
+      copyBtn.textContent = "Failed";
 
       // Clear any existing feedback timeout
       if (this.feedbackTimeout) {
@@ -493,7 +508,7 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = 'Copy';
+        copyBtn.textContent = "Copy";
         this.feedbackTimeout = null;
       }, 2000);
     }
@@ -501,8 +516,8 @@ class SocialShareButton {
 
   destroy() {
     if (this.handleKeydown) {
-      if (typeof document !== 'undefined') {
-        document.removeEventListener('keydown', this.handleKeydown);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("keydown", this.handleKeydown);
       }
       this.handleKeydown = null;
     }
@@ -528,11 +543,17 @@ class SocialShareButton {
 
     // Remove custom color handlers
     if (this.button && this.customColorMouseEnterHandler) {
-      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
+      this.button.removeEventListener(
+        "mouseenter",
+        this.customColorMouseEnterHandler,
+      );
       this.customColorMouseEnterHandler = null;
     }
     if (this.button && this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
+      this.button.removeEventListener(
+        "mouseleave",
+        this.customColorMouseLeaveHandler,
+      );
       this.customColorMouseLeaveHandler = null;
     }
 
@@ -545,7 +566,7 @@ class SocialShareButton {
     }
 
     // Shared body overflow management: only decrement if this instance owns the lock
-    if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
+    if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
       // Decrement counter (guard against negative)
       if (SocialShareButton.openModalCount > 0) {
         SocialShareButton.openModalCount--;
@@ -554,7 +575,7 @@ class SocialShareButton {
 
       // Restore original overflow only when all modals are closed
       if (SocialShareButton.openModalCount === 0) {
-        document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
+        document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
         SocialShareButton.originalBodyOverflow = null;
       }
     }
@@ -571,14 +592,14 @@ class SocialShareButton {
 
     // Update URL in modal if it exists
     if (this.modal) {
-      const input = this.modal.querySelector('.social-share-link-input input');
+      const input = this.modal.querySelector(".social-share-link-input input");
       if (input) {
         input.value = this.options.url;
       }
     }
 
     // Reapply custom colors if color option changed
-    if ('buttonColor' in options || 'buttonHoverColor' in options) {
+    if ("buttonColor" in options || "buttonHoverColor" in options) {
       this.applyCustomColors();
     }
   }
@@ -587,38 +608,44 @@ class SocialShareButton {
     if (!this.button) return;
 
     // Remove legacy global style tag to prevent cross-instance color bleed.
-    const styleTag = document.getElementById('social-share-custom-colors');
+    const styleTag = document.getElementById("social-share-custom-colors");
     if (styleTag && styleTag.parentNode) {
       styleTag.parentNode.removeChild(styleTag);
     }
 
     if (this.customColorMouseEnterHandler) {
-      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
+      this.button.removeEventListener(
+        "mouseenter",
+        this.customColorMouseEnterHandler,
+      );
       this.customColorMouseEnterHandler = null;
     }
     if (this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
+      this.button.removeEventListener(
+        "mouseleave",
+        this.customColorMouseLeaveHandler,
+      );
       this.customColorMouseLeaveHandler = null;
     }
 
-    this.button.style.removeProperty('background-color');
-    this.button.style.removeProperty('background-image');
-    this.button.style.removeProperty('border-color');
+    this.button.style.removeProperty("background-color");
+    this.button.style.removeProperty("background-image");
+    this.button.style.removeProperty("border-color");
 
-    const baseColor = this.options.buttonColor || '';
+    const baseColor = this.options.buttonColor || "";
     const hoverColor = this.options.buttonHoverColor || baseColor;
 
     if (!baseColor && !hoverColor) return;
 
     if (baseColor) {
-      this.button.style.backgroundImage = 'none';
+      this.button.style.backgroundImage = "none";
       this.button.style.backgroundColor = baseColor;
       this.button.style.borderColor = baseColor;
     }
 
     this.customColorMouseEnterHandler = () => {
       if (hoverColor) {
-        this.button.style.backgroundImage = 'none';
+        this.button.style.backgroundImage = "none";
         this.button.style.backgroundColor = hoverColor;
         this.button.style.borderColor = hoverColor;
       }
@@ -626,20 +653,26 @@ class SocialShareButton {
 
     this.customColorMouseLeaveHandler = () => {
       if (baseColor) {
-        this.button.style.backgroundImage = 'none';
+        this.button.style.backgroundImage = "none";
         this.button.style.backgroundColor = baseColor;
         this.button.style.borderColor = baseColor;
       } else {
-        this.button.style.removeProperty('background-color');
-        this.button.style.removeProperty('background-image');
-        this.button.style.removeProperty('border-color');
+        this.button.style.removeProperty("background-color");
+        this.button.style.removeProperty("background-image");
+        this.button.style.removeProperty("border-color");
       }
     };
 
     // Note: Custom color handlers are managed separately (not in listeners)
     // because they need to be removed/reapplied when colors change
-    this.button.addEventListener('mouseenter', this.customColorMouseEnterHandler);
-    this.button.addEventListener('mouseleave', this.customColorMouseLeaveHandler);
+    this.button.addEventListener(
+      "mouseenter",
+      this.customColorMouseEnterHandler,
+    );
+    this.button.addEventListener(
+      "mouseleave",
+      this.customColorMouseLeaveHandler,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -665,8 +698,8 @@ class SocialShareButton {
    */
   _getContainer() {
     if (!this.options.container) return null;
-    if (typeof document === 'undefined') return null;
-    return typeof this.options.container === 'string'
+    if (typeof document === "undefined") return null;
+    return typeof this.options.container === "string"
       ? document.querySelector(this.options.container)
       : this.options.container;
   }
@@ -697,7 +730,7 @@ class SocialShareButton {
 
     const payload = {
       version: ANALYTICS_SCHEMA_VERSION,
-      source: 'social-share-button',
+      source: "social-share-button",
       eventName,
       interactionType,
       platform: extra.platform || null,
@@ -714,14 +747,14 @@ class SocialShareButton {
     // Optional console output for development / debugging
     if (this.options.debug) {
       // eslint-disable-next-line no-console
-      console.log('[SocialShareButton Analytics]', payload);
+      console.log("[SocialShareButton Analytics]", payload);
     }
 
     // Path 1 — DOM CustomEvent (framework-agnostic, CDN-friendly)
     // Bubbles from the container element so delegated listeners work naturally.
-    if (typeof window !== 'undefined' && typeof CustomEvent !== 'undefined') {
+    if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
       try {
-        const domEvent = new CustomEvent('social-share', {
+        const domEvent = new CustomEvent("social-share", {
           bubbles: true,
           cancelable: false,
           composed: true, // crosses shadow-DOM boundaries; safe to set in all envs
@@ -733,7 +766,7 @@ class SocialShareButton {
     }
 
     // Path 2 — onAnalytics callback (direct, single-consumer hook)
-    if (typeof this.options.onAnalytics === 'function') {
+    if (typeof this.options.onAnalytics === "function") {
       try {
         this.options.onAnalytics(payload);
       } catch (_) {}
@@ -742,7 +775,7 @@ class SocialShareButton {
     // Path 3 — plugin / adapter registry (supports multiple simultaneous consumers)
     if (Array.isArray(this.options.analyticsPlugins)) {
       for (const plugin of this.options.analyticsPlugins) {
-        if (plugin && typeof plugin.track === 'function') {
+        if (plugin && typeof plugin.track === "function") {
           try {
             plugin.track(payload);
           } catch (_) {}
@@ -757,10 +790,10 @@ SocialShareButton.openModalCount = 0;
 SocialShareButton.originalBodyOverflow = null;
 
 // Export for different module systems
-if (typeof module !== 'undefined' && module.exports) {
+if (typeof module !== "undefined" && module.exports) {
   module.exports = SocialShareButton;
 }
 
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   window.SocialShareButton = SocialShareButton;
 }

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -219,7 +219,7 @@ class SocialShareButton {
   redditTitle = `${title}${description ? " - " + description : ""}`;
 
   // Email: description in body, title in subject
-  emailBody = `${description ? description : ""}`;
+  emailBody = `${title}${description ? description : ""}`;
 
   const encodedWhatsapp = encodeURIComponent(whatsappMessage);
   const encodedFacebook = encodeURIComponent(facebookMessage);

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -5,39 +5,35 @@
  */
 
 /** Analytics event schema version. Increment when the payload shape changes. */
-const ANALYTICS_SCHEMA_VERSION = "1.0";
+const ANALYTICS_SCHEMA_VERSION = '1.0';
 
 class SocialShareButton {
   constructor(options = {}) {
     this.options = {
-      url:
-        options.url ||
-        (typeof window !== "undefined" ? window.location.href : ""),
-      title:
-        options.title ||
-        (typeof document !== "undefined" ? document.title : ""),
-      description: options.description || "",
+      url: options.url || (typeof window !== 'undefined' ? window.location.href : ''),
+      title: options.title || (typeof document !== 'undefined' ? document.title : ''),
+      description: options.description || '',
       hashtags: options.hashtags || [],
-      via: options.via || "",
+      via: options.via || '',
       platforms: options.platforms || [
-        "whatsapp",
-        "facebook",
-        "twitter",
-        "linkedin",
-        "telegram",
-        "reddit",
+        'whatsapp',
+        'facebook',
+        'twitter',
+        'linkedin',
+        'telegram',
+        'reddit',
       ],
-      theme: options.theme || "dark",
-      buttonText: options.buttonText || "Share",
-      customClass: options.customClass || "",
-      buttonColor: options.buttonColor || "",
-      buttonHoverColor: options.buttonHoverColor || "",
+      theme: options.theme || 'dark',
+      buttonText: options.buttonText || 'Share',
+      customClass: options.customClass || '',
+      buttonColor: options.buttonColor || '',
+      buttonHoverColor: options.buttonHoverColor || '',
       onShare: options.onShare || null,
       onCopy: options.onCopy || null,
       container: options.container || null,
       showButton: options.showButton !== false,
-      buttonStyle: options.buttonStyle || "default",
-      modalPosition: options.modalPosition || "center",
+      buttonStyle: options.buttonStyle || 'default',
+      modalPosition: options.modalPosition || 'center',
       // Analytics — the library emits events but never collects or sends data itself.
       // Website owners wire up their own analytics tools via these options.
       analytics: options.analytics !== false, // set to false to disable all event emission
@@ -55,13 +51,12 @@ class SocialShareButton {
     this.handleKeydown = null;
     this.listeners = []; // Central registry for all event listeners
 
-    this.openTimeout = null;  // Track setTimeout for openModal animation
+    this.openTimeout = null; // Track setTimeout for openModal animation
     this.closeTimeout = null; // Track setTimeout for closeModal animation
     this.feedbackTimeout = null; // Track setTimeout for copy feedback reset
     this.ownsBodyLock = false; // Track if this instance owns the body overflow lock
     this.eventsAttached = false; // Guard against multiple attachEvents() calls
     this.isDestroyed = false; // Track if instance has been destroyed (prevents async callbacks)
-
 
     if (this.options.container) {
       this.init();
@@ -78,9 +73,9 @@ class SocialShareButton {
   }
 
   createButton() {
-    const button = document.createElement("button");
+    const button = document.createElement('button');
     button.className = `social-share-btn ${this.options.buttonStyle} ${this.options.customClass}`;
-    button.setAttribute("aria-label", "Share");
+    button.setAttribute('aria-label', 'Share');
     button.innerHTML = `
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="share-icon">
         <path d="M18 16.08C17.24 16.08 16.56 16.38 16.04 16.85L8.91 12.7C8.96 12.47 9 12.24 9 12C9 11.76 8.96 11.53 8.91 11.3L15.96 7.19C16.5 7.69 17.21 8 18 8C19.66 8 21 6.66 21 5C21 3.34 19.66 2 18 2C16.34 2 15 3.34 15 5C15 5.24 15.04 5.47 15.09 5.7L8.04 9.81C7.5 9.31 6.79 9 6 9C4.34 9 3 10.34 3 12C3 13.66 4.34 15 6 15C6.79 15 7.5 14.69 8.04 14.19L15.16 18.35C15.11 18.56 15.08 18.78 15.08 19C15.08 20.61 16.39 21.92 18 21.92C19.61 21.92 20.92 20.61 20.92 19C20.92 17.39 19.61 16.08 18 16.08Z" fill="currentColor"/>
@@ -91,7 +86,7 @@ class SocialShareButton {
     this.button = button;
     if (this.options.container) {
       const container =
-        typeof this.options.container === "string"
+        typeof this.options.container === 'string'
           ? document.querySelector(this.options.container)
           : this.options.container;
 
@@ -102,9 +97,9 @@ class SocialShareButton {
   }
 
   createModal() {
-    const modal = document.createElement("div");
+    const modal = document.createElement('div');
     modal.className = `social-share-modal-overlay ${this.options.theme}`;
-    modal.style.display = "none";
+    modal.style.display = 'none';
     modal.innerHTML = `
       <div class="social-share-modal-content ${this.options.modalPosition}">
         <div class="social-share-modal-header">
@@ -122,12 +117,12 @@ class SocialShareButton {
       </div>
     `;
 
-    const urlInputContainer = modal.querySelector(".social-share-link-input");
-    const urlInput = document.createElement("input");
-    urlInput.type = "text";
+    const urlInputContainer = modal.querySelector('.social-share-link-input');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
     urlInput.value = this.options.url;
     urlInput.readOnly = true;
-    urlInput.setAttribute("aria-label", "URL to share");
+    urlInput.setAttribute('aria-label', 'URL to share');
     urlInputContainer.appendChild(urlInput);
 
     this.modal = modal;
@@ -137,38 +132,38 @@ class SocialShareButton {
   getPlatformsHTML() {
     const platforms = {
       whatsapp: {
-        name: "WhatsApp",
-        color: "#25D366",
+        name: 'WhatsApp',
+        color: '#25D366',
         icon: '<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>',
       },
       facebook: {
-        name: "Facebook",
-        color: "#1877F2",
+        name: 'Facebook',
+        color: '#1877F2',
         icon: '<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>',
       },
       twitter: {
-        name: "X",
-        color: "#000000",
+        name: 'X',
+        color: '#000000',
         icon: '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>',
       },
       linkedin: {
-        name: "LinkedIn",
-        color: "#0A66C2",
+        name: 'LinkedIn',
+        color: '#0A66C2',
         icon: '<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>',
       },
       telegram: {
-        name: "Telegram",
-        color: "#0088cc",
+        name: 'Telegram',
+        color: '#0088cc',
         icon: '<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>',
       },
       reddit: {
-        name: "Reddit",
-        color: "#FF4500",
+        name: 'Reddit',
+        color: '#FF4500',
         icon: '<path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/>',
       },
       email: {
-        name: "Email",
-        color: "#7f7f7f",
+        name: 'Email',
+        color: '#7f7f7f',
         icon: '<path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>',
       },
     };
@@ -186,60 +181,55 @@ class SocialShareButton {
           </button>
         `;
       })
-      .join("");
+      .join('');
   }
 
   getShareURL(platform) {
-  const { url, title, description, hashtags, via } = this.options;
-  const encodedUrl = encodeURIComponent(url);
-  const encodedTitle = encodeURIComponent(title);
-  const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
+    const { url, title, description, hashtags, via } = this.options;
+    const encodedUrl = encodeURIComponent(url);
+    const encodedTitle = encodeURIComponent(title);
+    const hashtagString = hashtags.length ? '#' + hashtags.join(' #') : '';
 
-  // Build platform-specific messages with customizable parameters
-  let whatsappMessage,
-    facebookMessage,
-    twitterMessage,
-    telegramMessage,
-    redditTitle,
-    emailBody;
+    // Build platform-specific messages with customizable parameters
+    let whatsappMessage, facebookMessage, twitterMessage, telegramMessage, redditTitle, emailBody;
 
-  // WhatsApp: title + description + hashtags
-  whatsappMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    // WhatsApp: title + description + hashtags
+    whatsappMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
 
-  // Facebook: title + description + hashtags
-  facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    // Facebook: title + description + hashtags
+    facebookMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
 
-  // Twitter: title + description + hashtags + via
-  twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
+    // Twitter: title + description + hashtags + via
+    twitterMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n' + hashtagString : ''}`;
 
-  // Telegram: title + description + hashtags
-  telegramMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    // Telegram: title + description + hashtags
+    telegramMessage = `${title}${description ? '\n\n' + description : ''}${hashtagString ? '\n\n' + hashtagString : ''}`;
 
-  // Reddit: title + description
-  redditTitle = `${title}${description ? " - " + description : ""}`;
+    // Reddit: title + description
+    redditTitle = `${title}${description ? ' - ' + description : ''}`;
 
-  // Email: description in body, title in subject
-  emailBody = `${description ? description : ""}`;
+    // Email: description in body, title in subject
+    emailBody = `${title}${description ? '\n\n' + description : ''}`;
 
-  const encodedWhatsapp = encodeURIComponent(whatsappMessage);
-  const encodedFacebook = encodeURIComponent(facebookMessage);
-  const encodedTwitter = encodeURIComponent(twitterMessage);
-  const encodedTelegram = encodeURIComponent(telegramMessage);
-  const encodedReddit = encodeURIComponent(redditTitle);
-  const encodedEmail = encodeURIComponent(emailBody);
+    const encodedWhatsapp = encodeURIComponent(whatsappMessage);
+    const encodedFacebook = encodeURIComponent(facebookMessage);
+    const encodedTwitter = encodeURIComponent(twitterMessage);
+    const encodedTelegram = encodeURIComponent(telegramMessage);
+    const encodedReddit = encodeURIComponent(redditTitle);
+    const encodedEmail = encodeURIComponent(emailBody);
 
-  const urls = {
-    whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
-    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
-    twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-    telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
-    reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
-    email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
-  };
+    const urls = {
+      whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
+      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
+      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? '&via=' + encodeURIComponent(via) : ''}`,
+      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
+      reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
+      email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
+    };
 
-  return urls[platform] || "";
-}
+    return urls[platform] || '';
+  }
 
   addEventListener(element, type, handler, options = false) {
     if (!element) return;
@@ -264,7 +254,7 @@ class SocialShareButton {
     // Button click to open modal
     if (this.button) {
       const openModalHandler = () => this.openModal();
-      this.addEventListener(this.button, "click", openModalHandler);
+      this.addEventListener(this.button, 'click', openModalHandler);
     }
 
     // Modal overlay click to close
@@ -273,43 +263,41 @@ class SocialShareButton {
         this.closeModal();
       }
     };
-    this.addEventListener(this.modal, "click", modalClickHandler);
+    this.addEventListener(this.modal, 'click', modalClickHandler);
 
     // Close button
-    const closeBtn = this.modal.querySelector(".social-share-modal-close");
+    const closeBtn = this.modal.querySelector('.social-share-modal-close');
     const closeBtnHandler = () => this.closeModal();
-    this.addEventListener(closeBtn, "click", closeBtnHandler);
+    this.addEventListener(closeBtn, 'click', closeBtnHandler);
 
     // Platform buttons
-    const platformBtns = this.modal.querySelectorAll(
-      ".social-share-platform-btn",
-    );
+    const platformBtns = this.modal.querySelectorAll('.social-share-platform-btn');
     platformBtns.forEach((btn) => {
       const platformHandler = () => {
         const platform = btn.dataset.platform;
         this.share(platform);
       };
-      this.addEventListener(btn, "click", platformHandler);
+      this.addEventListener(btn, 'click', platformHandler);
     });
 
     // Copy button
-    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
+    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
     const copyBtnHandler = () => this.copyLink();
-    this.addEventListener(copyBtn, "click", copyBtnHandler);
+    this.addEventListener(copyBtn, 'click', copyBtnHandler);
 
     // Input click to select
-    const input = this.modal.querySelector(".social-share-link-input input");
+    const input = this.modal.querySelector('.social-share-link-input input');
     const inputSelectHandler = (e) => e.target.select();
-    this.addEventListener(input, "click", inputSelectHandler);
+    this.addEventListener(input, 'click', inputSelectHandler);
 
     // ESC key to close
     this.handleKeydown = (e) => {
-      if (e.key === "Escape" && this.isModalOpen) {
+      if (e.key === 'Escape' && this.isModalOpen) {
         this.closeModal();
       }
     };
-    if (typeof document !== "undefined") {
-       document.addEventListener("keydown", this.handleKeydown);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', this.handleKeydown);
     }
 
     this.eventsAttached = true; // Mark as attached
@@ -319,11 +307,11 @@ class SocialShareButton {
     if (!this.modal) return;
 
     this.isModalOpen = true;
-    this.modal.style.display = "flex";
-    this._emit("social_share_popup_open", "popup_open");
+    this.modal.style.display = 'flex';
+    this._emit('social_share_popup_open', 'popup_open');
 
     // Shared body overflow management: only increment counter if this instance doesn't already own the lock
-    if (typeof document !== "undefined" && document.body) {
+    if (typeof document !== 'undefined' && document.body) {
       if (!this.ownsBodyLock) {
         // Only increment if this instance doesn't already own a lock
         if (SocialShareButton.openModalCount === 0) {
@@ -333,7 +321,7 @@ class SocialShareButton {
         SocialShareButton.openModalCount++;
         this.ownsBodyLock = true; // Mark that this instance owns a lock
       }
-      document.body.style.overflow = "hidden";
+      document.body.style.overflow = 'hidden';
     }
 
     // Clear any pending animations (both open and close to prevent race conditions)
@@ -348,8 +336,9 @@ class SocialShareButton {
 
     // Animate in
     this.openTimeout = setTimeout(() => {
-      if (this.modal) { // Safety check in case destroy() was called
-        this.modal.classList.add("active");
+      if (this.modal) {
+        // Safety check in case destroy() was called
+        this.modal.classList.add('active');
       }
       this.openTimeout = null;
     }, 10);
@@ -358,8 +347,8 @@ class SocialShareButton {
   closeModal() {
     if (!this.modal) return; // Safety check
 
-    this.modal.classList.remove("active");
-    this._emit("social_share_popup_close", "popup_close");
+    this.modal.classList.remove('active');
+    this._emit('social_share_popup_close', 'popup_close');
 
     // Clear any pending animations (both open and close to prevent race conditions)
     if (this.openTimeout) {
@@ -372,12 +361,13 @@ class SocialShareButton {
     }
 
     this.closeTimeout = setTimeout(() => {
-      if (this.modal) { // Safety check in case destroy() was called
+      if (this.modal) {
+        // Safety check in case destroy() was called
         this.isModalOpen = false;
-        this.modal.style.display = "none";
+        this.modal.style.display = 'none';
 
         // Shared body overflow management: only decrement if this instance owns the lock
-        if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
+        if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
           // Decrement counter (guard against negative)
           if (SocialShareButton.openModalCount > 0) {
             SocialShareButton.openModalCount--;
@@ -386,7 +376,7 @@ class SocialShareButton {
 
           // Restore original overflow only when all modals are closed
           if (SocialShareButton.openModalCount === 0) {
-            document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
+            document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
             SocialShareButton.originalBodyOverflow = null;
           }
         }
@@ -399,25 +389,21 @@ class SocialShareButton {
     const shareUrl = this.getShareURL(platform);
 
     if (shareUrl) {
-      this._emit("social_share_click", "share", { platform });
+      this._emit('social_share_click', 'share', { platform });
 
-      if (platform === "email") {
+      if (platform === 'email') {
         window.location.href = shareUrl;
       } else {
-        window.open(
-          shareUrl,
-          "_blank",
-          "noopener,noreferrer,width=600,height=600",
-        );
+        window.open(shareUrl, '_blank', 'noopener,noreferrer,width=600,height=600');
       }
 
-      this._emit("social_share_success", "share", { platform });
+      this._emit('social_share_success', 'share', { platform });
 
       if (this.options.onShare) {
         this.options.onShare(platform, this.options.url);
       }
     } else {
-      this._emit("social_share_error", "error", {
+      this._emit('social_share_error', 'error', {
         platform,
         errorMessage: `No share URL configured for platform: ${platform}`,
       });
@@ -425,8 +411,8 @@ class SocialShareButton {
   }
 
   copyLink() {
-    const input = this.modal.querySelector(".social-share-link-input input");
-    const copyBtn = this.modal.querySelector(".social-share-copy-btn");
+    const input = this.modal.querySelector('.social-share-link-input input');
+    const copyBtn = this.modal.querySelector('.social-share-copy-btn');
 
     // Check if clipboard API is available
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -436,9 +422,9 @@ class SocialShareButton {
           // Guard against async callback after destroy
           if (this.isDestroyed) return;
 
-          copyBtn.textContent = "Copied!";
-          copyBtn.classList.add("copied");
-          this._emit("social_share_copy", "copy");
+          copyBtn.textContent = 'Copied!';
+          copyBtn.classList.add('copied');
+          this._emit('social_share_copy', 'copy');
 
           if (this.options.onCopy) {
             this.options.onCopy(this.options.url);
@@ -452,13 +438,12 @@ class SocialShareButton {
           // Track feedback timeout to prevent callback after destroy
           this.feedbackTimeout = setTimeout(() => {
             if (this.isDestroyed || !copyBtn) return; // Safety check
-            copyBtn.textContent = "Copy";
-            copyBtn.classList.remove("copied");
+            copyBtn.textContent = 'Copy';
+            copyBtn.classList.remove('copied');
             this.feedbackTimeout = null;
           }, 2000);
         })
         .catch(() => {
-
           // Fallback to manual selection
           this.fallbackCopy(input, copyBtn);
         });
@@ -475,11 +460,11 @@ class SocialShareButton {
     try {
       input.select();
       input.setSelectionRange(0, 99999); // For mobile devices
-      document.execCommand("copy");
+      document.execCommand('copy');
 
-      copyBtn.textContent = "Copied!";
-      copyBtn.classList.add("copied");
-      this._emit("social_share_copy", "copy");
+      copyBtn.textContent = 'Copied!';
+      copyBtn.classList.add('copied');
+      this._emit('social_share_copy', 'copy');
 
       if (this.options.onCopy) {
         this.options.onCopy(this.options.url);
@@ -493,12 +478,12 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = "Copy";
-        copyBtn.classList.remove("copied");
+        copyBtn.textContent = 'Copy';
+        copyBtn.classList.remove('copied');
         this.feedbackTimeout = null;
       }, 2000);
     } catch (_err) {
-      copyBtn.textContent = "Failed";
+      copyBtn.textContent = 'Failed';
 
       // Clear any existing feedback timeout
       if (this.feedbackTimeout) {
@@ -508,7 +493,7 @@ class SocialShareButton {
       // Track feedback timeout to prevent callback after destroy
       this.feedbackTimeout = setTimeout(() => {
         if (this.isDestroyed || !copyBtn) return; // Safety check
-        copyBtn.textContent = "Copy";
+        copyBtn.textContent = 'Copy';
         this.feedbackTimeout = null;
       }, 2000);
     }
@@ -516,8 +501,8 @@ class SocialShareButton {
 
   destroy() {
     if (this.handleKeydown) {
-      if (typeof document !== "undefined") {
-        document.removeEventListener("keydown", this.handleKeydown);
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('keydown', this.handleKeydown);
       }
       this.handleKeydown = null;
     }
@@ -543,17 +528,11 @@ class SocialShareButton {
 
     // Remove custom color handlers
     if (this.button && this.customColorMouseEnterHandler) {
-      this.button.removeEventListener(
-        "mouseenter",
-        this.customColorMouseEnterHandler,
-      );
+      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
       this.customColorMouseEnterHandler = null;
     }
     if (this.button && this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener(
-        "mouseleave",
-        this.customColorMouseLeaveHandler,
-      );
+      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
       this.customColorMouseLeaveHandler = null;
     }
 
@@ -566,7 +545,7 @@ class SocialShareButton {
     }
 
     // Shared body overflow management: only decrement if this instance owns the lock
-    if (this.ownsBodyLock && typeof document !== "undefined" && document.body) {
+    if (this.ownsBodyLock && typeof document !== 'undefined' && document.body) {
       // Decrement counter (guard against negative)
       if (SocialShareButton.openModalCount > 0) {
         SocialShareButton.openModalCount--;
@@ -575,7 +554,7 @@ class SocialShareButton {
 
       // Restore original overflow only when all modals are closed
       if (SocialShareButton.openModalCount === 0) {
-        document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
+        document.body.style.overflow = SocialShareButton.originalBodyOverflow || '';
         SocialShareButton.originalBodyOverflow = null;
       }
     }
@@ -592,14 +571,14 @@ class SocialShareButton {
 
     // Update URL in modal if it exists
     if (this.modal) {
-      const input = this.modal.querySelector(".social-share-link-input input");
+      const input = this.modal.querySelector('.social-share-link-input input');
       if (input) {
         input.value = this.options.url;
       }
     }
 
     // Reapply custom colors if color option changed
-    if ("buttonColor" in options || "buttonHoverColor" in options) {
+    if ('buttonColor' in options || 'buttonHoverColor' in options) {
       this.applyCustomColors();
     }
   }
@@ -608,44 +587,38 @@ class SocialShareButton {
     if (!this.button) return;
 
     // Remove legacy global style tag to prevent cross-instance color bleed.
-    const styleTag = document.getElementById("social-share-custom-colors");
+    const styleTag = document.getElementById('social-share-custom-colors');
     if (styleTag && styleTag.parentNode) {
       styleTag.parentNode.removeChild(styleTag);
     }
 
     if (this.customColorMouseEnterHandler) {
-      this.button.removeEventListener(
-        "mouseenter",
-        this.customColorMouseEnterHandler,
-      );
+      this.button.removeEventListener('mouseenter', this.customColorMouseEnterHandler);
       this.customColorMouseEnterHandler = null;
     }
     if (this.customColorMouseLeaveHandler) {
-      this.button.removeEventListener(
-        "mouseleave",
-        this.customColorMouseLeaveHandler,
-      );
+      this.button.removeEventListener('mouseleave', this.customColorMouseLeaveHandler);
       this.customColorMouseLeaveHandler = null;
     }
 
-    this.button.style.removeProperty("background-color");
-    this.button.style.removeProperty("background-image");
-    this.button.style.removeProperty("border-color");
+    this.button.style.removeProperty('background-color');
+    this.button.style.removeProperty('background-image');
+    this.button.style.removeProperty('border-color');
 
-    const baseColor = this.options.buttonColor || "";
+    const baseColor = this.options.buttonColor || '';
     const hoverColor = this.options.buttonHoverColor || baseColor;
 
     if (!baseColor && !hoverColor) return;
 
     if (baseColor) {
-      this.button.style.backgroundImage = "none";
+      this.button.style.backgroundImage = 'none';
       this.button.style.backgroundColor = baseColor;
       this.button.style.borderColor = baseColor;
     }
 
     this.customColorMouseEnterHandler = () => {
       if (hoverColor) {
-        this.button.style.backgroundImage = "none";
+        this.button.style.backgroundImage = 'none';
         this.button.style.backgroundColor = hoverColor;
         this.button.style.borderColor = hoverColor;
       }
@@ -653,26 +626,20 @@ class SocialShareButton {
 
     this.customColorMouseLeaveHandler = () => {
       if (baseColor) {
-        this.button.style.backgroundImage = "none";
+        this.button.style.backgroundImage = 'none';
         this.button.style.backgroundColor = baseColor;
         this.button.style.borderColor = baseColor;
       } else {
-        this.button.style.removeProperty("background-color");
-        this.button.style.removeProperty("background-image");
-        this.button.style.removeProperty("border-color");
+        this.button.style.removeProperty('background-color');
+        this.button.style.removeProperty('background-image');
+        this.button.style.removeProperty('border-color');
       }
     };
 
     // Note: Custom color handlers are managed separately (not in listeners)
     // because they need to be removed/reapplied when colors change
-    this.button.addEventListener(
-      "mouseenter",
-      this.customColorMouseEnterHandler,
-    );
-    this.button.addEventListener(
-      "mouseleave",
-      this.customColorMouseLeaveHandler,
-    );
+    this.button.addEventListener('mouseenter', this.customColorMouseEnterHandler);
+    this.button.addEventListener('mouseleave', this.customColorMouseLeaveHandler);
   }
 
   // ---------------------------------------------------------------------------
@@ -698,8 +665,8 @@ class SocialShareButton {
    */
   _getContainer() {
     if (!this.options.container) return null;
-    if (typeof document === "undefined") return null;
-    return typeof this.options.container === "string"
+    if (typeof document === 'undefined') return null;
+    return typeof this.options.container === 'string'
       ? document.querySelector(this.options.container)
       : this.options.container;
   }
@@ -730,7 +697,7 @@ class SocialShareButton {
 
     const payload = {
       version: ANALYTICS_SCHEMA_VERSION,
-      source: "social-share-button",
+      source: 'social-share-button',
       eventName,
       interactionType,
       platform: extra.platform || null,
@@ -747,14 +714,14 @@ class SocialShareButton {
     // Optional console output for development / debugging
     if (this.options.debug) {
       // eslint-disable-next-line no-console
-      console.log("[SocialShareButton Analytics]", payload);
+      console.log('[SocialShareButton Analytics]', payload);
     }
 
     // Path 1 — DOM CustomEvent (framework-agnostic, CDN-friendly)
     // Bubbles from the container element so delegated listeners work naturally.
-    if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
+    if (typeof window !== 'undefined' && typeof CustomEvent !== 'undefined') {
       try {
-        const domEvent = new CustomEvent("social-share", {
+        const domEvent = new CustomEvent('social-share', {
           bubbles: true,
           cancelable: false,
           composed: true, // crosses shadow-DOM boundaries; safe to set in all envs
@@ -766,7 +733,7 @@ class SocialShareButton {
     }
 
     // Path 2 — onAnalytics callback (direct, single-consumer hook)
-    if (typeof this.options.onAnalytics === "function") {
+    if (typeof this.options.onAnalytics === 'function') {
       try {
         this.options.onAnalytics(payload);
       } catch (_) {}
@@ -775,7 +742,7 @@ class SocialShareButton {
     // Path 3 — plugin / adapter registry (supports multiple simultaneous consumers)
     if (Array.isArray(this.options.analyticsPlugins)) {
       for (const plugin of this.options.analyticsPlugins) {
-        if (plugin && typeof plugin.track === "function") {
+        if (plugin && typeof plugin.track === 'function') {
           try {
             plugin.track(payload);
           } catch (_) {}
@@ -790,10 +757,10 @@ SocialShareButton.openModalCount = 0;
 SocialShareButton.originalBodyOverflow = null;
 
 // Export for different module systems
-if (typeof module !== "undefined" && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = SocialShareButton;
 }
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   window.SocialShareButton = SocialShareButton;
 }

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -190,57 +190,56 @@ class SocialShareButton {
   }
 
   getShareURL(platform) {
-    const { url, title, description, hashtags, via } = this.options;
-    const encodedUrl = encodeURIComponent(url);
-    const encodedTitle = encodeURIComponent(title);
-    // const encodedDesc = encodeURIComponent(description);
-    const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
+  const { url, title, description, hashtags, via } = this.options;
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+  const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
 
-    // Build platform-specific messages with customizable parameters
-    let whatsappMessage,
-      facebookMessage,
-      twitterMessage,
-      telegramMessage,
-      redditTitle,
-      emailBody;
+  // Build platform-specific messages with customizable parameters
+  let whatsappMessage,
+    facebookMessage,
+    twitterMessage,
+    telegramMessage,
+    redditTitle,
+    emailBody;
 
-    // WhatsApp: Casual with emoji
-    whatsappMessage = `\u{1F680} ${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}\n\nLive on the site \u{1F440}\nClean UI, smooth flow \u{2014} worth peeking\n\u{1F447}`;
+  // WhatsApp: title + description + hashtags
+  whatsappMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Facebook: Title + Description
-    facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+  // Facebook: title + description + hashtags
+  facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Twitter: Title + Description + Hashtags + Via
-    twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
+  // Twitter: title + description + hashtags + via
+  twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
 
-    // Telegram: Casual with emoji
-    telegramMessage = `\u{1F517} ${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}\n\nLive + working\nClean stuff, take a look \u{1F447}`;
+  // Telegram: title + description + hashtags
+  telegramMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
 
-    // Reddit: Title + Description
-    redditTitle = `${title}${description ? " - " + description : ""}`;
+  // Reddit: title + description
+  redditTitle = `${title}${description ? " - " + description : ""}`;
 
-    // Email: Friendly greeting
-    emailBody = `Hey \u{1F44B}\n\nSharing a clean project I came across:\n${title}${description ? "\n\n" + description : ""}\n\nLive, simple, and usable \u{2014} take a look \u{1F447}`;
+  // Email: description in body, title in subject
+  emailBody = `${description ? description : ""}`;
 
-    const encodedWhatsapp = encodeURIComponent(whatsappMessage);
-    const encodedFacebook = encodeURIComponent(facebookMessage);
-    const encodedTwitter = encodeURIComponent(twitterMessage);
-    const encodedTelegram = encodeURIComponent(telegramMessage);
-    const encodedReddit = encodeURIComponent(redditTitle);
-    const encodedEmail = encodeURIComponent(emailBody);
+  const encodedWhatsapp = encodeURIComponent(whatsappMessage);
+  const encodedFacebook = encodeURIComponent(facebookMessage);
+  const encodedTwitter = encodeURIComponent(twitterMessage);
+  const encodedTelegram = encodeURIComponent(telegramMessage);
+  const encodedReddit = encodeURIComponent(redditTitle);
+  const encodedEmail = encodeURIComponent(emailBody);
 
-    const urls = {
-      whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
-      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
-      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
-      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-      telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
-      reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
-      email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
-    };
+  const urls = {
+    whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
+    twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+    telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
+    reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
+    email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
+  };
 
-    return urls[platform] || "";
-  }
+  return urls[platform] || "";
+}
 
   addEventListener(element, type, handler, options = false) {
     if (!element) return;

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -189,7 +189,7 @@ class SocialShareButton {
       .join("");
   }
 
-  getShareURL(platform) {
+    getShareURL(platform) {
     const { url, title, description, hashtags, via } = this.options;
     const encodedUrl = encodeURIComponent(url);
     const encodedTitle = encodeURIComponent(title);

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -190,56 +190,44 @@ class SocialShareButton {
   }
 
   getShareURL(platform) {
-  const { url, title, description, hashtags, via } = this.options;
-  const encodedUrl = encodeURIComponent(url);
-  const encodedTitle = encodeURIComponent(title);
-  const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
+    const { url, title, description, hashtags, via } = this.options;
+    const encodedUrl = encodeURIComponent(url);
+    const encodedTitle = encodeURIComponent(title);
+    const hashtagString = hashtags.length ? "#" + hashtags.join(" #") : "";
 
-  // Build platform-specific messages with customizable parameters
-  let whatsappMessage,
-    facebookMessage,
-    twitterMessage,
-    telegramMessage,
-    redditTitle,
-    emailBody;
+    let whatsappMessage,
+      facebookMessage,
+      twitterMessage,
+      telegramMessage,
+      redditTitle,
+      emailBody;
 
-  // WhatsApp: title + description + hashtags
-  whatsappMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    whatsappMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
+    telegramMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    redditTitle = `${title}${description ? " - " + description : ""}`;
+    emailBody = `${title}${description ? "\n\n" + description : ""}`;
 
-  // Facebook: title + description + hashtags
-  facebookMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
+    const encodedWhatsapp = encodeURIComponent(whatsappMessage);
+    const encodedFacebook = encodeURIComponent(facebookMessage);
+    const encodedTwitter = encodeURIComponent(twitterMessage);
+    const encodedTelegram = encodeURIComponent(telegramMessage);
+    const encodedReddit = encodeURIComponent(redditTitle);
+    const encodedEmail = encodeURIComponent(emailBody);
 
-  // Twitter: title + description + hashtags + via
-  twitterMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n" + hashtagString : ""}`;
+    const urls = {
+      whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
+      facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
+      twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
+      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+      telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
+      reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
+      email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
+    };
 
-  // Telegram: title + description + hashtags
-  telegramMessage = `${title}${description ? "\n\n" + description : ""}${hashtagString ? "\n\n" + hashtagString : ""}`;
-
-  // Reddit: title + description
-  redditTitle = `${title}${description ? " - " + description : ""}`;
-
-  // Email: description in body, title in subject
-  emailBody = `${title}${description ? description : ""}`;
-
-  const encodedWhatsapp = encodeURIComponent(whatsappMessage);
-  const encodedFacebook = encodeURIComponent(facebookMessage);
-  const encodedTwitter = encodeURIComponent(twitterMessage);
-  const encodedTelegram = encodeURIComponent(telegramMessage);
-  const encodedReddit = encodeURIComponent(redditTitle);
-  const encodedEmail = encodeURIComponent(emailBody);
-
-  const urls = {
-    whatsapp: `https://wa.me/?text=${encodedWhatsapp}%20${encodedUrl}`,
-    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedFacebook}`,
-    twitter: `https://twitter.com/intent/tweet?text=${encodedTwitter}&url=${encodedUrl}${via ? "&via=" + encodeURIComponent(via) : ""}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-    telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTelegram}`,
-    reddit: `https://reddit.com/submit?url=${encodedUrl}&title=${encodedReddit}`,
-    email: `mailto:?subject=${encodedTitle}&body=${encodedEmail}%20${encodedUrl}`,
-  };
-
-  return urls[platform] || "";
-}
+    return urls[platform] || "";
+  }
 
   addEventListener(element, type, handler, options = false) {
     if (!element) return;


### PR DESCRIPTION
### Addressed Issues:
Fixes #100


### Screenshots/Recordings:
Not applicable. This change updates share message generation logic in `getShareURL(platform)` and does not introduce a UI change.


### Additional Notes:
This PR is focused only on issue #100.

It removes hardcoded promotional text that was being appended to generated share messages for some platforms. After this change, the generated share content is based only on the documented user-provided options such as `title`, `description`, `hashtags`, `via`, and `url`.


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Social share messages for WhatsApp, Telegram, and Email now display essential information only (title, description, and hashtags)—decorative emoji and marketing text have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->