### PR TITLE
fix: add MutationObserver fallback for delayed container rendering in SPAs

### DIFF
--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -87,13 +87,31 @@ class SocialShareButton {
 
     this.button = button;
     if (this.options.container) {
-      const container =
-        typeof this.options.container === "string"
-          ? document.querySelector(this.options.container)
-          : this.options.container;
+      if (typeof this.options.container === "string") {
+        const attachToContainer = () => {
+          const container = document.querySelector(this.options.container);
+          if (container && !container.contains(button)) {
+            container.appendChild(button);
+            return true;
+          }
+          return false;
+        };
 
-      if (container) {
-        container.appendChild(button);
+        // Try to attach immediately
+        if (!attachToContainer() && typeof document !== "undefined") {
+          // If not found, wait for it to appear in the DOM
+          const observer = new MutationObserver((mutations, obs) => {
+            if (attachToContainer()) {
+              obs.disconnect(); // Stop watching once attached
+            }
+          });
+          if (document.body) {
+            observer.observe(document.body, { childList: true, subtree: true });
+          }
+        }
+      } else {
+        // Container is already a DOM node
+        this.options.container.appendChild(button);
       }
     }
   }

--- a/src/social-share-button.js
+++ b/src/social-share-button.js
@@ -59,6 +59,7 @@ class SocialShareButton {
     this.ownsBodyLock = false; // Track if this instance owns the body overflow lock
     this.eventsAttached = false; // Guard against multiple attachEvents() calls
     this.isDestroyed = false; // Track if instance has been destroyed (prevents async callbacks)
+    this.containerObserver = null; // MutationObserver for deferred container attachment
 
     if (this.options.container) {
       this.init();
@@ -90,9 +91,11 @@ class SocialShareButton {
       if (typeof this.options.container === "string") {
         const attachToContainer = () => {
           const container = document.querySelector(this.options.container);
-          if (container && !container.contains(button)) {
-            container.appendChild(button);
-            return true;
+          if (container) {
+            if (!container.contains(button)) {
+              container.appendChild(button);
+            }
+            return true; // Container found — observer can stop
           }
           return false;
         };
@@ -100,13 +103,19 @@ class SocialShareButton {
         // Try to attach immediately
         if (!attachToContainer() && typeof document !== "undefined") {
           // If not found, wait for it to appear in the DOM
-          const observer = new MutationObserver((mutations, obs) => {
+          this.containerObserver = new MutationObserver((mutations, obs) => {
+            if (this.isDestroyed) { // Abort if instance was destroyed while waiting
+              obs.disconnect();
+              this.containerObserver = null;
+              return;
+            }
             if (attachToContainer()) {
               obs.disconnect(); // Stop watching once attached
+              this.containerObserver = null;
             }
           });
           if (document.body) {
-            observer.observe(document.body, { childList: true, subtree: true });
+            this.containerObserver.observe(document.body, { childList: true, subtree: true });
           }
         }
       } else {
@@ -608,6 +617,12 @@ class SocialShareButton {
         document.body.style.overflow = SocialShareButton.originalBodyOverflow || "";
         SocialShareButton.originalBodyOverflow = null;
       }
+    }
+
+    // Disconnect deferred container observer to prevent post-destroy attachment
+    if (this.containerObserver) {
+      this.containerObserver.disconnect();
+      this.containerObserver = null;
     }
 
     // Clear references (makes destroy idempotent)


### PR DESCRIPTION
## Problem

When `SocialShareButton` was initialized before the container element 
existed in the DOM (common in React/Vue/Angular SPAs), 
`document.querySelector()` returned `null` — causing the button to 
silently fail and never appear on the page.

---

## Changes

### 1. MutationObserver fallback for deferred container attachment
Modified `createButton()` to use a `MutationObserver` fallback:

1. Library first tries to attach the button immediately
2. If container is not found, a `MutationObserver` watches the DOM
3. The moment container appears, button is attached automatically
4. Observer is disconnected immediately after

### 2. Fixed `attachToContainer()` return value logic
Previously the function returned `false` when the container was found 
but already contained the button — causing the observer to never 
disconnect.

Now returns `true` whenever the container is found (regardless of 
whether button was appended), so the observer correctly stops watching.

### 3. Observer stored on instance (`this.containerObserver`)
The observer was previously a local `const` — `destroy()` had no way 
to reach it. Now stored as `this.containerObserver` for proper cleanup.

### 4. `isDestroyed` guard in observer callback
If `destroy()` is called while the observer is still waiting, the 
callback now aborts — preventing a zombie button from being appended 
after the instance is destroyed.

### 5. Observer disconnected in `destroy()`
`destroy()` now disconnects and nulls `this.containerObserver` to 
prevent memory leaks and post-destroy side effects.

---

## Result

| Scenario | Before | After |
|----------|--------|-------|
| Container not in DOM at init | ❌ Button missing | ✅ Auto-attached when ready |
| Button already in container | 🐛 Observer never stops | ✅ Observer disconnects |
| `destroy()` before container appears | 🐛 Memory leak + zombie button | ✅ Observer cleaned up |

No change required from the developer's side. The library handles 
timing automatically.
