### PR TITLE
ci: migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -162,7 +162,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -207,7 +207,7 @@ jobs:
           path: /tmp/pack
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -141,14 +141,13 @@ jobs:
             echo "- **GitHub Release:** ✗ (no draft found)" >> $GITHUB_STEP_SUMMARY
           fi
 
-  publish:
+  build:
     needs: release
     if: ${{ github.repository_owner == 'AOSSIE-Org' && needs.release.outputs.released == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Checkout code
@@ -166,7 +165,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -175,9 +173,6 @@ jobs:
       - name: Run linting
         run: pnpm run lint
 
-      - name: Update npm for Trusted Publishing
-        run: npm install -g npm@11.5.1
-
       - name: Sync version from VERSION file
         run: |
           VERSION="${{ needs.release.outputs.version }}"
@@ -185,11 +180,43 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
           echo "✓ package.json version set to $VERSION"
 
-      - name: Verify package contents
-        run: npm pack --dry-run
+      - name: Pack package
+        run: npm pack --pack-destination /tmp/pack
+
+      - name: Upload package tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: npm-package
+          path: /tmp/pack/*.tgz
+          retention-days: 1
+
+  publish:
+    needs: [release, build]
+    if: ${{ github.repository_owner == 'AOSSIE-Org' && needs.release.outputs.released == 'true' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download package tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: npm-package
+          path: /tmp/pack
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@11.5.1
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish /tmp/pack/*.tgz --provenance --access public
 
       - name: Publish Summary
         run: |

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Run linting
         run: pnpm run lint
 
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@11.5.1
+
       - name: Sync version from VERSION file
         run: |
           VERSION="${{ needs.release.outputs.version }}"
@@ -187,8 +190,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
       - name: Publish Summary
         run: |


### PR DESCRIPTION
# Addressed Issues:

N/A — operational CI fix, not tracked by an issue. Context: npm is deprecating "Bypass 2FA" granular access tokens (see https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/). Phase 1 (Aug 2026) already restricts these tokens for sensitive operations, and Phase 2 (~Jan 2027) removes their ability to publish at all, including to existing packages like `@aossie-org/social-share-button`. This mirrors the same migration already done for ThruBox-Client (AOSSIE-Org/ThruBox-Client#28) and IndexedDB-Import-Export (AOSSIE-Org/IndexedDB-Import-Export#61).

## Screenshots/Recordings:

N/A — CI workflow change only.

## Additional Notes:

- Removes the `NPMJS_TOKEN`-based auth from the `publish` job.
- Adds a pinned `npm install -g npm@11.5.1` step, since Trusted Publishing requires npm >= 11.5.1. Pinned to an exact version rather than `@latest` to avoid pulling unreviewed npm CLI code into a job that holds `id-token: write`.
- **Requires admin action before this is effective:** an org owner needs to configure a Trusted Publisher for `@aossie-org/social-share-button` on npmjs.com (Package Settings → Trusted Publisher → GitHub Actions → org `AOSSIE-Org`, repo `SocialShareButton`, workflow `version-release.yml`, allowed action `npm publish`). Until that's set up, this workflow will fail since it no longer supplies a token.
- Once a clean release runs through this successfully, the `NPMJS_TOKEN` secret used here can be removed.

## Checklist

- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use npm 11.5.1 for publishing.
  * Improved package publishing authentication through trusted publishing with provenance enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->