### PR TITLE
fix(pkg): make the package importable from ESM and CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,36 @@
   "name": "@aossie-org/social-share-button",
   "version": "1.0.4",
   "description": "Lightweight social sharing component for web applications",
-  "main": "src/social-share-button.js",
+  "main": "./src/social-share-button.js",
+  "module": "./src/social-share-button.mjs",
+  "exports": {
+    ".": {
+      "import": "./src/social-share-button.mjs",
+      "require": "./src/social-share-button.js",
+      "default": "./src/social-share-button.mjs"
+    },
+    "./analytics": {
+      "import": "./src/social-share-analytics.mjs",
+      "require": "./src/social-share-analytics.js",
+      "default": "./src/social-share-analytics.mjs"
+    },
+    "./react": "./src/social-share-button-react.jsx",
+    "./preact": "./src/social-share-button-preact.jsx",
+    "./qwik": "./src/social-share-button-qwik.tsx",
+    "./css": "./src/social-share-button.css",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "files": [
+    "src/package.json",
     "src/social-share-button.js",
+    "src/social-share-button.mjs",
     "src/social-share-button.css",
     "src/social-share-button-react.jsx",
+    "src/social-share-button-preact.jsx",
+    "src/social-share-button-qwik.tsx",
     "src/social-share-analytics.js",
+    "src/social-share-analytics.mjs",
     "README.md",
     "LICENSE"
   ],

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/social-share-analytics.mjs
+++ b/src/social-share-analytics.mjs
@@ -8,6 +8,7 @@ import adapters from "./social-share-analytics.js";
 
 export default adapters;
 export const {
+  SocialShareAnalyticsPlugin,
   GoogleAnalyticsAdapter,
   MixpanelAdapter,
   SegmentAdapter,

--- a/src/social-share-analytics.mjs
+++ b/src/social-share-analytics.mjs
@@ -1,0 +1,17 @@
+/**
+ * ES module entry point for the analytics adapters.
+ *
+ * social-share-analytics.js is also usable as a classic <script> tag, so it
+ * cannot contain `export` syntax. This file is the module entry instead.
+ */
+import adapters from "./social-share-analytics.js";
+
+export default adapters;
+export const {
+  GoogleAnalyticsAdapter,
+  MixpanelAdapter,
+  SegmentAdapter,
+  PlausibleAdapter,
+  PostHogAdapter,
+  CustomAdapter,
+} = adapters;

--- a/src/social-share-button.mjs
+++ b/src/social-share-button.mjs
@@ -1,0 +1,11 @@
+/**
+ * ES module entry point for SocialShareButton.
+ *
+ * social-share-button.js is also served directly to browsers as a classic
+ * <script> tag from the CDN, so it cannot contain `export` syntax. This file
+ * is the module entry instead, and simply re-exports the class from it.
+ */
+import SocialShareButton from "./social-share-button.js";
+
+export default SocialShareButton;
+export { SocialShareButton };


### PR DESCRIPTION
Fixes #234.

Please treat this as a proposal rather than a claim on the issue. I said in #234 that I would wait for a steer before sending code, and I have put the branch up anyway, which I want to be upfront about. Two of my three questions turned out to be answerable by measuring, so showing the diff seemed more useful than describing it. The third is still yours to call. Happy to close or reshape this if you would rather go another way.

## The problem

`package.json` declares `"type": "module"`, so every `.js` file in `src/` is treated as an ES module. The only export machinery in `src/social-share-button.js` is this, at the bottom:

```js
if (typeof module !== "undefined" && module.exports) {
  module.exports = SocialShareButton;
}
```

In an ES module `module` is undefined, so that block never runs. There is no `export` statement in the file either, so the module ends up with zero exports. Only the `window.SocialShareButton` assignment survives, which is exactly why the CDN path works and npm does not. `src/social-share-analytics.js` has the same latent problem.

## Why the fix is not the obvious one

My first instinct was to add `export default SocialShareButton;` to the core file. That would have broken the CDN for everyone, and I only caught it because I compiled the file the way a classic `<script>` does before committing to the approach:

```
current v1.0.4 core                  : parses as a classic <script>  OK
core + "export default" (my instinct): FAILS as a classic <script>
                                       SyntaxError: Unexpected token 'export'
```

`export` is only legal inside a module, and the README serves that exact file through `<script src="https://cdn.jsdelivr.net/gh/...">` on ten or so lines. So the core files have to stay free of export syntax.

The useful part is that they already are. Neither core file contains any `import` or `export` syntax, which means both are already valid CommonJS and the root `"type": "module"` is simply mislabelling them. So this tells Node the truth rather than rewriting the files:

1. **`src/package.json`** with `{ "type": "commonjs" }`. Nested `package.json` type scoping is standard Node, and it turns the existing `module.exports` blocks back into live code. Browsers never read `package.json`, so the CDN is untouched.
2. **`src/social-share-button.mjs`** and **`src/social-share-analytics.mjs`**, small ESM entry points that re-export from the CommonJS files.
3. **An `exports` map** wiring the `import` and `require` conditions, plus named subpaths.
4. **The `files` array** now ships the Preact and Qwik wrappers, which were listed nowhere and so were never published.

No library logic changed. Both core `.js` files are byte identical to `main`.

## Nothing that worked before stops working

An `exports` map normally cuts off deep imports, and the README documents `import "@aossie-org/social-share-button/src/social-share-button.css"`. I kept `"./src/*": "./src/*"` specifically so that path and every other documented one keeps resolving. The tradeoff is that this gives up most of the encapsulation an `exports` map would normally buy you. If you would rather make the clean break, that is a one line deletion plus a README update and I am glad to do it.

## Verification

Run against a real `npm pack` plus install, Node v22.21.0, no bundler unless stated.

Before, on published `1.0.4`:

```
import S from '...'        SyntaxError: does not provide an export named 'default'
import * as ns from '...'  namespace keys: []
require('...')             [Module: null prototype] {}   no class
```

After:

```
ESM default import    : function SocialShareButton
ESM named import      : function SocialShareButton
CJS require           : function SocialShareButton
./analytics, both     : 7 exports, the 6 adapters plus the base class
old deep css path     : resolves, README unbroken
new ./css subpath     : resolves
```

| Check | Result |
|---|---|
| classic `<script>` tag in a browser | loads, `window.SocialShareButton` is a function, buttons render, no console errors |
| esbuild, main entry and `/react` and `/preact` | bundles |
| Rollup with node-resolve and commonjs | bundles and runs |
| exports-blind legacy resolution via `main` | resolves to the class |
| every `exports` target cross checked against the packed tarball | all present |
| `npm run lint`, `npm run format:check` | pass |

I have only tested Node v22.21.0. The features used here, nested `type` scoping and `exports` maps, are old and widely supported, but I would rather say what I actually ran than imply a matrix I did not.

The README needs no change, because the snippet it already documents now works as written.

## Notes and open questions

- **CJS without a build step.** This uses the CommonJS the repo already had, so there is no `dist/` and no toolchain. If you would prefer a real build step, that is a bigger change and I did not want to introduce one uninvited. This is the question I could not answer by measuring.
- **The version is not bumped.** Nothing reaches consumers until a release, which I assumed you would rather own.
- **The two new `.mjs` files are not covered by CI.** The lint glob is `src/**/*.{js,jsx}` and Prettier's is similar. I left both scripts alone because the CI standard is synced from Template-Repo and did not seem like mine to widen. I ran eslint and Prettier against the new files directly and both are clean. Say the word if you want the globs widened to include `mjs`.
- **The wrappers still read the class off the global.** `/react`, `/preact` and `/qwik` are now real subpaths but none of them import the core, and there are no `peerDependencies` declared. That is pre-existing and unchanged, but shipping the files is what makes it reachable, so it is worth knowing.
- **New subpaths are undocumented.** `/analytics`, `/css`, `/react`, `/preact`, `/qwik` all work now and none are in the README. Happy to write that up here or separately, whichever you prefer.

## On #233

No `types` field here, deliberately. That belongs with #233, which is @Mansi2007275's and which they said they want to write themselves. Two of the entries here are already condition objects that a `types` key drops straight into; the four plain string subpaths would each need converting to an object first, which is mechanical. I am not asking for that issue and this does not block it.

---

Used Claude as a research assistant while digging into this. The diagnosis, the classic script check that changed the approach, and every measurement above are mine, run locally against a packed build of this branch.
