### PR TITLE
fix(landing): Copy Link buttons actually copy the URL (#196)

### DIFF
--- a/landing-page/src/components/Hero.tsx
+++ b/landing-page/src/components/Hero.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { copyTextToClipboard } from "../lib/copyTextToClipboard";
 
 const SHARE_DEMO_URL = "https://social-share-button.aossie.org";
@@ -10,6 +10,7 @@ const SHARE_DEMO_URL = "https://social-share-button.aossie.org";
 export function Hero() {
   const router = useRouter();
   const [copyLabel, setCopyLabel] = useState("Copy Link");
+  const copyRequestId = useRef(0);
 
   const handleNavigate = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
     if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0) {
@@ -22,9 +23,18 @@ export function Hero() {
   };
 
   const handleCopyLink = async () => {
+    const requestId = ++copyRequestId.current;
     const ok = await copyTextToClipboard(SHARE_DEMO_URL);
+    if (requestId !== copyRequestId.current) {
+      return;
+    }
     setCopyLabel(ok ? "Copied!" : "Failed");
-    window.setTimeout(() => setCopyLabel("Copy Link"), 2000);
+    window.setTimeout(() => {
+      if (requestId !== copyRequestId.current) {
+        return;
+      }
+      setCopyLabel("Copy Link");
+    }, 2000);
   };
 
   return (

--- a/landing-page/src/components/Hero.tsx
+++ b/landing-page/src/components/Hero.tsx
@@ -2,9 +2,14 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
+import { useState } from "react";
+import { copyTextToClipboard } from "../lib/copyTextToClipboard";
+
+const SHARE_DEMO_URL = "https://social-share-button.aossie.org";
 
 export function Hero() {
   const router = useRouter();
+  const [copyLabel, setCopyLabel] = useState("Copy Link");
 
   const handleNavigate = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
     if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0) {
@@ -14,6 +19,12 @@ export function Hero() {
     setTimeout(() => {
       router.push(href);
     }, 200);
+  };
+
+  const handleCopyLink = async () => {
+    const ok = await copyTextToClipboard(SHARE_DEMO_URL);
+    setCopyLabel(ok ? "Copied!" : "Failed");
+    window.setTimeout(() => setCopyLabel("Copy Link"), 2000);
   };
 
   return (
@@ -105,8 +116,12 @@ export function Hero() {
 
               <div className="flex items-center gap-2 bg-background rounded-full p-1 pl-4 border-2 border-[#FFCC00]">
                 <span className="text-xs md:text-sm text-neutral-500 truncate flex-1 hidden sm:block">social-share-button.aossie.org</span>
-                <button className="bg-[#FFCC00] text-black px-4 py-2 rounded-full text-sm font-bold">
-                  Copy Link
+                <button
+                  type="button"
+                  onClick={handleCopyLink}
+                  className="bg-[#FFCC00] text-black px-4 py-2 rounded-full text-sm font-bold"
+                >
+                  {copyLabel}
                 </button>
               </div>
 

--- a/landing-page/src/components/Playground.tsx
+++ b/landing-page/src/components/Playground.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { copyTextToClipboard } from "../lib/copyTextToClipboard";
 
 type ButtonStyleKey = "default" | "primary" | "compact" | "icon-only";
@@ -48,14 +48,24 @@ export function Playground() {
   const [color, setColor] = useState<string>(COLORS[0]);
   const [platforms, setPlatforms] = useState(INITIAL_PLATFORMS);
   const [copyLabel, setCopyLabel] = useState("Copy Link");
+  const copyRequestId = useRef(0);
 
   const textColor = textColorFor(color);
   const activePlatforms = platforms.filter((p) => p.active);
 
   const handleCopyLink = async () => {
+    const requestId = ++copyRequestId.current;
     const ok = await copyTextToClipboard(PLAYGROUND_SHARE_URL);
+    if (requestId !== copyRequestId.current) {
+      return;
+    }
     setCopyLabel(ok ? "Copied!" : "Failed");
-    window.setTimeout(() => setCopyLabel("Copy Link"), 2000);
+    window.setTimeout(() => {
+      if (requestId !== copyRequestId.current) {
+        return;
+      }
+      setCopyLabel("Copy Link");
+    }, 2000);
   };
 
   const togglePlatform = (name: string) => {

--- a/landing-page/src/components/Playground.tsx
+++ b/landing-page/src/components/Playground.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { copyTextToClipboard } from "../lib/copyTextToClipboard";
 
 type ButtonStyleKey = "default" | "primary" | "compact" | "icon-only";
 
@@ -18,6 +19,8 @@ const COLORS = [
   "#a855f7",
   "#ffffff",
 ];
+
+const PLAYGROUND_SHARE_URL = "https://socialsharebutton.com";
 
 const INITIAL_PLATFORMS = [
   { name: "WhatsApp", icon: "W", active: true, color: "#25D366" },
@@ -44,9 +47,16 @@ export function Playground() {
   const [style, setStyle] = useState<ButtonStyleKey>("default");
   const [color, setColor] = useState<string>(COLORS[0]);
   const [platforms, setPlatforms] = useState(INITIAL_PLATFORMS);
+  const [copyLabel, setCopyLabel] = useState("Copy Link");
 
   const textColor = textColorFor(color);
   const activePlatforms = platforms.filter((p) => p.active);
+
+  const handleCopyLink = async () => {
+    const ok = await copyTextToClipboard(PLAYGROUND_SHARE_URL);
+    setCopyLabel(ok ? "Copied!" : "Failed");
+    window.setTimeout(() => setCopyLabel("Copy Link"), 2000);
+  };
 
   const togglePlatform = (name: string) => {
     setPlatforms((prev) =>
@@ -150,6 +160,8 @@ export function Playground() {
                     https://socialsharebutton.com
                   </span>
                   <button
+                    type="button"
+                    onClick={handleCopyLink}
                     className={`px-6 py-2 rounded-full text-sm font-bold transition-colors ${isPrimary ? "border-2" : ""}`}
                     style={
                       isPrimary
@@ -161,7 +173,7 @@ export function Playground() {
                           }
                     }
                   >
-                    Copy Link
+                    {copyLabel}
                   </button>
                 </div>
               )}

--- a/landing-page/src/lib/copyTextToClipboard.ts
+++ b/landing-page/src/lib/copyTextToClipboard.ts
@@ -1,0 +1,27 @@
+/** Copy text to the clipboard; returns false when both APIs fail. */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to execCommand path (e.g. insecure context / denied permission).
+  }
+
+  try {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "absolute";
+    textArea.style.left = "-9999px";
+    document.body.appendChild(textArea);
+    textArea.select();
+    textArea.setSelectionRange(0, text.length);
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textArea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/landing-page/src/lib/copyTextToClipboard.ts
+++ b/landing-page/src/lib/copyTextToClipboard.ts
@@ -16,11 +16,13 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
     textArea.style.position = "absolute";
     textArea.style.left = "-9999px";
     document.body.appendChild(textArea);
-    textArea.select();
-    textArea.setSelectionRange(0, text.length);
-    const ok = document.execCommand("copy");
-    document.body.removeChild(textArea);
-    return ok;
+    try {
+      textArea.select();
+      textArea.setSelectionRange(0, text.length);
+      return document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textArea);
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
###  Addressed Issues:
Fixes #196

### Description
On the landing page, **Copy Link** in `Hero` and `Playground` was a button with no click handler, so nothing was copied to the clipboard.

- Added `copyTextToClipboard` (`clipboard.writeText` + `execCommand` fallback)
- Wired both buttons; brief Copied!/Failed label feedback

###  Screenshots/Recordings:
N/A (clipboard behavior)

## Checklist
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)

Will post this PR in the SocialShareButton Discord channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional share-link copying from the landing-page hero and playground.
  * Added success and failure feedback after copy attempts.
  * Status labels automatically reset after two seconds.
  * Added clipboard support with a fallback for broader browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->